### PR TITLE
Wire Up CloudTrail Events

### DIFF
--- a/lambda-registrator/delete_event.go
+++ b/lambda-registrator/delete_event.go
@@ -1,0 +1,15 @@
+package main
+
+type DeleteEvent struct {
+	ServiceName    string
+	EnterpriseMeta *EnterpriseMeta
+}
+
+func (e DeleteEvent) Identifier() string {
+	return e.ServiceName
+}
+
+func (e DeleteEvent) Reconcile(env Environment) error {
+	env.Logger.Info("Deleting Lambda", "service-name", e.ServiceName)
+	return nil
+}

--- a/lambda-registrator/fixtures/create_function.json
+++ b/lambda-registrator/fixtures/create_function.json
@@ -1,0 +1,8 @@
+{
+    "detail": {
+        "eventName": "CreateFunction20150331",
+        "responseElements": {
+            "functionArn": "arn:aws:lambda:us-east-1:111111111111:function:lambda-1234"
+        }
+    }
+}

--- a/lambda-registrator/fixtures/tag_resource.json
+++ b/lambda-registrator/fixtures/tag_resource.json
@@ -1,0 +1,8 @@
+{
+    "detail": {
+        "eventName": "TagResource20170331v2",
+        "requestParameters": {
+            "resource": "arn:aws:lambda:us-east-1:111111111111:function:lambda-1234"
+        }
+    }
+}

--- a/lambda-registrator/fixtures/unsupported.json
+++ b/lambda-registrator/fixtures/unsupported.json
@@ -1,0 +1,8 @@
+{
+    "detail": {
+        "eventName": "Unsupported",
+        "responseElements": {
+            "functionArn": "arn:aws:lambda:us-east-1:111111111111:function:lambda-1234"
+        }
+    }
+}

--- a/lambda-registrator/fixtures/untag_resource.json
+++ b/lambda-registrator/fixtures/untag_resource.json
@@ -1,0 +1,8 @@
+{
+    "detail": {
+        "eventName": "UntagResource20170331v2",
+        "requestParameters": {
+            "resource": "arn:aws:lambda:us-east-1:111111111111:function:lambda-1234"
+        }
+    }
+}

--- a/lambda-registrator/go.mod
+++ b/lambda-registrator/go.mod
@@ -10,9 +10,11 @@ require (
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/hashicorp/consul/api v1.12.0 // indirect
 	github.com/hashicorp/consul/sdk v0.9.0 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
 	github.com/hashicorp/go-hclog v0.12.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.0.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/go-uuid v1.0.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.0 // indirect

--- a/lambda-registrator/go.sum
+++ b/lambda-registrator/go.sum
@@ -20,6 +20,7 @@ github.com/hashicorp/consul/api v1.12.0/go.mod h1:6pVBMo0ebnYdt2S3H87XhekM/HHrUo
 github.com/hashicorp/consul/sdk v0.8.0/go.mod h1:GBvyrGALthsZObzUGsfgHZQDXjg4lOjagTIwIR1vPms=
 github.com/hashicorp/consul/sdk v0.9.0 h1:NGSHAU7X3yDCjo8WBUbNOtD3BSqv8u0vu3+zNxgmxQI=
 github.com/hashicorp/consul/sdk v0.9.0/go.mod h1:GBvyrGALthsZObzUGsfgHZQDXjg4lOjagTIwIR1vPms=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -30,6 +31,8 @@ github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjh
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5Oi2viEzc=
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=

--- a/lambda-registrator/main.go
+++ b/lambda-registrator/main.go
@@ -2,21 +2,78 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/hashicorp/go-multierror"
+	"github.com/mitchellh/mapstructure"
 )
 
 func main() {
 	lambda.Start(HandleRequest)
 }
 
-func HandleRequest(context.Context, interface{}) (string, error) {
-	_, err := SetupEnvironment()
+func HandleRequest(ctx context.Context, rawEvent map[string]interface{}) (string, error) {
+	env, err := SetupEnvironment()
 
 	if err != nil {
-		return "", fmt.Errorf("setting up consul environment  %w", err)
+		// We can't use the logger because of the error.
+		fmt.Println("Error setting up the environment: %w", err)
+		return "", fmt.Errorf("setting up consul environment:  %w", err)
 	}
 
-	return "", nil
+	events, err := GetEvents(env, rawEvent)
+	if err != nil {
+		env.Logger.Warn("Error getting events", "error", err)
+		return "", fmt.Errorf("error getting events: %w", err)
+	}
+
+	env.Logger.Info("Processing events", "count", len(events))
+
+	var resultErr error
+
+	for _, event := range events {
+		err := event.Reconcile(env)
+
+		if err != nil {
+			env.Logger.Warn("Error reconciling event", "error", err, "identifier", event.Identifier())
+			resultErr = multierror.Append(resultErr, err)
+		}
+	}
+
+	return "", resultErr
+}
+
+type Event interface {
+	Reconcile(Environment) error
+	Identifier() string
+}
+
+func GetEvents(env Environment, data map[string]interface{}) ([]Event, error) {
+	source, ok := data["source"].(string)
+	if !ok {
+		return nil, fmt.Errorf("missing event source")
+	}
+
+	env.Logger.Info("Received event", "source", source)
+	switch source {
+	case "aws.events":
+		return nil, errors.New("Unimplemented")
+	case "aws.lambda":
+		var e AWSEvent
+		err := mapstructure.Decode(data, &e)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding aws.lambda event %s", err)
+		}
+
+		events, err := env.AWSEventToEvents(e)
+		if err != nil {
+			return nil, fmt.Errorf("error converting aws.lambda event our event %s", err)
+		}
+
+		return events, nil
+	}
+
+	return nil, fmt.Errorf("unprocessable event source %q", source)
 }

--- a/lambda-registrator/trigger.go
+++ b/lambda-registrator/trigger.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	sdkARN "github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"strings"
+)
+
+const (
+	prefix                = "serverless.consul.hashicorp.com/v1alpha1"
+	enabledTag            = prefix + "/lambda/enabled"
+	arnTag                = prefix + "/lambda/arn"
+	payloadPassthroughTag = prefix + "/lambda/payload-passhthrough"
+	regionTag             = prefix + "/lambda/region"
+	partitionTag          = prefix + "/lambda/partition"
+	namespaceTag          = prefix + "/lambda/namespace"
+	aliasesTag            = prefix + "/lambda/aliases"
+)
+
+var (
+	regionUndefinedErr = errors.New("region isn't populated")
+	arnUndefinedErr    = errors.New("arn isn't populated")
+	notEnterpriseErr   = errors.New("namespaces and admin partitions can't be used with open source Consul")
+)
+
+type AWSEvent struct {
+	Detail Detail `json:"detail"`
+}
+
+type Detail struct {
+	EventName         string            `json:"eventName"`
+	ResponseElements  ResponseElements  `json:"responseElements"`
+	RequestParameters RequestParameters `json:"requestParameters"`
+}
+
+type ResponseElements struct {
+	FunctionArn string `json:"functionArn"`
+}
+
+type RequestParameters struct {
+	FunctionName string `json:"functionName"`
+	Resource     string `json:"resource"`
+}
+
+type EnterpriseMeta struct {
+	Namespace string
+	Partition string
+}
+
+func (e Environment) AWSEventToEvents(event AWSEvent) ([]Event, error) {
+	var events []Event
+	var arn string
+	switch event.Detail.EventName {
+	case "CreateFunction20150331", "CreateFunction":
+		arn = event.Detail.ResponseElements.FunctionArn
+	case "TagResource20170331v2", "TagResource20170331", "TagResource",
+		"UntagResource20170331v2", "UntagResource20170331", "UntagResource":
+		arn = event.Detail.RequestParameters.Resource
+	default:
+		return events, fmt.Errorf("unsupported event kind %s", event.Detail.EventName)
+	}
+
+	if arn == "" {
+		return events, arnUndefinedErr
+	}
+
+	upsertEvents, err := e.GetLambdaData(arn)
+
+	if err != nil {
+		return events, err
+	}
+
+	for _, e := range upsertEvents {
+		events = append(events, e)
+	}
+
+	return events, nil
+}
+
+func (e Environment) GetLambdaData(arn string) ([]UpsertEvent, error) {
+	createService := false
+	payloadPassthrough := false
+	var aliases []string
+
+	// This is terrible, but it saves tons of API calls to GetFunction just for
+	// the function name.
+	parsedARN, err := sdkARN.Parse(arn)
+	if err != nil {
+		return nil, err
+	}
+	functionName := ""
+	if i := strings.IndexByte(parsedARN.Resource, ':'); i != -1 {
+		functionName = parsedARN.Resource[i+1:]
+	}
+
+	tagOutput, err := e.Lambda.ListTags(&lambda.ListTagsInput{
+		Resource: &arn,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	tags := tagOutput.Tags
+
+	if tags[enabledTag] != nil {
+		createService = *tags[enabledTag] == "true"
+	}
+
+	if tags[payloadPassthroughTag] != nil {
+		payloadPassthrough = *tags[payloadPassthroughTag] == "true"
+	}
+
+	var em *EnterpriseMeta
+	if tags[namespaceTag] != nil {
+		em = &EnterpriseMeta{Namespace: *tags[namespaceTag], Partition: "default"}
+	}
+
+	if tags[partitionTag] != nil {
+		partition := *tags[partitionTag]
+		if em == nil {
+			em = &EnterpriseMeta{Namespace: "default", Partition: partition}
+		} else {
+			em.Partition = partition
+		}
+	}
+
+	if !e.IsEnterprise && em != nil {
+		return nil, notEnterpriseErr
+	}
+
+	if aliasesRaw, ok := tags[aliasesTag]; ok {
+		aliases = strings.Split(*aliasesRaw, ",")
+	}
+
+	baseUpsertEvent := UpsertEvent{
+		CreateService:      createService,
+		PayloadPassthrough: payloadPassthrough,
+		ServiceName:        functionName,
+		ARN:                arn,
+		EnterpriseMeta:     em,
+	}
+
+	upsertEvents := []UpsertEvent{baseUpsertEvent}
+
+	for _, aliasName := range aliases {
+		e := baseUpsertEvent
+		e.ServiceName = fmt.Sprintf("%s-%s", baseUpsertEvent.ServiceName, aliasName)
+		e.ARN = fmt.Sprintf("%s:%s", arn, aliasName)
+		upsertEvents = append(upsertEvents, e)
+	}
+
+	return upsertEvents, nil
+}

--- a/lambda-registrator/trigger_test.go
+++ b/lambda-registrator/trigger_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAWSEventToEvents(t *testing.T) {
+	arn := "arn:aws:lambda:us-east-1:111111111111:function:lambda-1234"
+	s1 := UpsertEvent{
+		CreateService: true,
+		ServiceName:   "lambda-1234",
+		ARN:           arn,
+	}
+	s1WithAliases := UpsertEventPlusAliases{
+		UpsertEvent: s1,
+	}
+
+	lambda := mockLambdaClient(s1WithAliases)
+	env := mockEnvironment(lambda, nil)
+	loadFixture := func(filename string) AWSEvent {
+		d, err := os.ReadFile("./fixtures/" + filename + ".json")
+		require.NoError(t, err)
+
+		var e AWSEvent
+		err = json.Unmarshal(d, &e)
+		require.NoError(t, err)
+
+		return e
+	}
+
+	cases := []string{"tag_resource", "untag_resource", "create_function"}
+
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			event := loadFixture(c)
+
+			events, err := env.AWSEventToEvents(event)
+			require.NoError(t, err)
+			require.Len(t, events, 1)
+			e, ok := events[0].(UpsertEvent)
+			require.True(t, ok)
+			require.Equal(t, e.CreateService, s1.CreateService)
+			require.Equal(t, e.ServiceName, s1.ServiceName)
+			require.Equal(t, e.ARN, s1.ARN)
+		})
+	}
+
+	t.Run("with an unsupported event name", func(t *testing.T) {
+		event := loadFixture("unsupported")
+		_, err := env.AWSEventToEvents(event)
+		require.Error(t, err)
+	})
+}
+
+func TestGetLambdaData(t *testing.T) {
+	arn := "arn:aws:lambda:us-east-1:111111111111:function:lambda-1234"
+	makeService := func(enterprise bool, alias string) UpsertEvent {
+		e := UpsertEvent{
+			ARN:                arn,
+			PayloadPassthrough: true,
+			CreateService:      true,
+			ServiceName:        "lambda-1234",
+		}
+		if enterprise {
+			e.EnterpriseMeta = &EnterpriseMeta{Namespace: "n", Partition: "p"}
+		}
+		if alias != "" {
+			e.ServiceName = e.ServiceName + "-" + alias
+			e.ARN = e.ARN + ":" + alias
+		}
+		return e
+	}
+	cases := map[string]struct {
+		arn          string
+		upsertEvents []UpsertEventPlusAliases
+		expected     []UpsertEvent
+		err          bool
+		enterprise   bool
+	}{
+		"Invalid arn": {
+			arn: "1234",
+			err: true,
+		},
+		"Error fetching tags": {
+			arn:          arn,
+			err:          true,
+			upsertEvents: []UpsertEventPlusAliases{},
+		},
+		"Enterprise meta is passed without enterprise Consul": {
+			arn: arn,
+			err: true,
+			upsertEvents: []UpsertEventPlusAliases{
+				{
+					UpsertEvent: UpsertEvent{
+						CreateService:  true,
+						ServiceName:    "lambda-1234",
+						EnterpriseMeta: &EnterpriseMeta{Namespace: "n", Partition: "p"},
+					},
+				},
+			},
+		},
+		"Everything is passed - Enterprise": {
+			arn: arn,
+			err: false,
+			upsertEvents: []UpsertEventPlusAliases{
+				{
+					UpsertEvent: makeService(true, ""),
+				},
+			},
+			enterprise: true,
+			expected: []UpsertEvent{
+				makeService(true, ""),
+			},
+		},
+		"Everything is passed - OSS": {
+			arn: arn,
+			err: false,
+			upsertEvents: []UpsertEventPlusAliases{
+				{
+					UpsertEvent: makeService(false, ""),
+				},
+			},
+			enterprise: false,
+			expected: []UpsertEvent{
+				makeService(false, ""),
+			},
+		},
+		"Aliases": {
+			arn: arn,
+			err: false,
+			upsertEvents: []UpsertEventPlusAliases{
+				{
+					UpsertEvent: makeService(false, ""),
+					Aliases:     []string{"a1", "a2"},
+				},
+			},
+			enterprise: false,
+			expected: []UpsertEvent{
+				makeService(false, ""),
+				makeService(false, "a1"),
+				makeService(false, "a2"),
+			},
+		},
+	}
+
+	for n, c := range cases {
+		t.Run(n, func(t *testing.T) {
+			lambda := mockLambdaClient(c.upsertEvents...)
+			env := mockEnvironment(lambda, nil)
+			env.IsEnterprise = c.enterprise
+
+			events, err := env.GetLambdaData(arn)
+			if c.err {
+				require.Error(t, err)
+				return
+			}
+
+			require.Equal(t, c.expected, events)
+		})
+	}
+}

--- a/lambda-registrator/upsert_event.go
+++ b/lambda-registrator/upsert_event.go
@@ -1,0 +1,18 @@
+package main
+
+type UpsertEvent struct {
+	CreateService      bool
+	PayloadPassthrough bool
+	ServiceName        string
+	ARN                string
+	EnterpriseMeta     *EnterpriseMeta
+}
+
+func (e UpsertEvent) Identifier() string {
+	return e.ARN
+}
+
+func (e UpsertEvent) Reconcile(env Environment) error {
+	env.Logger.Info("Upserting Lambda", "arn", e.ARN)
+	return nil
+}


### PR DESCRIPTION
This theoretically does a few things:
- [Sets EventBridge up to send Lambda create, tag and untag events to Lambda registrator](https://github.com/hashicorp/terraform-aws-consul-lambda-registrator/compare/wire-up-incremental-events?expand=1#diff-2866bd8138aac421dce1fc79320da2e8ca12466f55e7639142c03565843b1a14R123).
- Converts those events [to upsert](https://github.com/hashicorp/terraform-aws-consul-lambda-registrator/compare/wire-up-incremental-events?expand=1#diff-d7b70c8fb7122183f9038ef21fcbb86ac6d10bcf3cee0e74205e091d86bbf9abR69) and delete events.
- Sets up the boilerplate for handling the [upsert](https://github.com/hashicorp/terraform-aws-consul-lambda-registrator/compare/wire-up-incremental-events?expand=1#diff-1359d794008b6425b8dcc864e9abcb20b6b92879f7454d5bc4dc56f1b5de710eR15) and [delete events](https://github.com/hashicorp/terraform-aws-consul-lambda-registrator/compare/wire-up-incremental-events?expand=1#diff-5fdbba24c05570bb22525fd9be7245dab9d99e064dd3a3e22cc06d73f7a9d19dR12).

The only testing I've done on this so far is unit testing and ensuring the terraform example in `./examples/simple` successfully applies. I have a working POC that I'm basing this on, so it shouldn't be too far off. I'm still pushing off end-to-end testing until I have something I can actually test end-to-end.