### PR TITLE
Switch from using a go binary to an ECR container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+lambda-registrator
+fixtures

--- a/examples/simple/ecr.tf
+++ b/examples/simple/ecr.tf
@@ -1,0 +1,36 @@
+locals {
+  ecr_repository_name = "demo-lambda-container-${var.suffix}"
+  ecr_image_tag       = "latest"
+  account_id          = data.aws_caller_identity.current.account_id
+}
+
+resource "aws_ecr_repository" "lambda-registrator" {
+  name = local.ecr_repository_name
+}
+
+resource "null_resource" "push-lambda-registrator-to-ecr" {
+  triggers = {
+    always_run = timestamp()
+  }
+
+  provisioner "local-exec" {
+    command = <<EOF
+    aws ecr get-login-password --region ${var.region} | docker login --username AWS --password-stdin ${local.account_id}.dkr.ecr.${var.region}.amazonaws.com
+    cd ../../lambda-registrator
+    docker build -t ${aws_ecr_repository.lambda-registrator.repository_url}:${local.ecr_image_tag} .
+    docker push ${aws_ecr_repository.lambda-registrator.repository_url}:${local.ecr_image_tag}
+    EOF
+  }
+
+  depends_on = [
+    aws_ecr_repository.lambda-registrator
+  ]
+}
+
+data "aws_ecr_image" "lambda-registrator" {
+  depends_on = [
+    null_resource.push-lambda-registrator-to-ecr
+  ]
+  repository_name = local.ecr_repository_name
+  image_tag       = local.ecr_image_tag
+}

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -11,6 +11,8 @@ provider "aws" {
   region = var.region
 }
 
+data "aws_caller_identity" "current" {}
+
 data "aws_availability_zones" "available" {
   filter {
     name   = "opt-in-status"
@@ -57,4 +59,5 @@ module "lambda-registration" {
   consul_http_addr       = local.consul_http_addr
   consul_ca_cert_path    = var.tls ? aws_ssm_parameter.ca-cert[0].name : ""
   consul_http_token_path = var.acls ? aws_ssm_parameter.acl-token[0].name : ""
+  ecr_image_uri          = "${aws_ecr_repository.lambda-registrator.repository_url}@${data.aws_ecr_image.lambda-registrator.id}"
 }

--- a/lambda-registrator/Dockerfile
+++ b/lambda-registrator/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.18-alpine as build
+
+ENV CGO_ENABLED 0
+WORKDIR /build
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN go build -o /bin/lambda-registrator
+
+FROM public.ecr.aws/lambda/provided:al2
+COPY --from=build /bin/lambda-registrator /bin/lambda-registrator
+ENTRYPOINT [ "/bin/lambda-registrator" ]

--- a/modules/lambda-registrator/main.tf
+++ b/modules/lambda-registrator/main.tf
@@ -1,14 +1,3 @@
-locals {
-  registration_path = "registration.zip"
-}
-
-data "archive_file" "lambda_registration_zip" {
-  type = "zip"
-  // TODO This only works in dev but that is good enough for now.
-  source_file = "../../lambda-registrator/lambda-registrator"
-  output_path = local.registration_path
-}
-
 resource "aws_iam_role" "registration" {
   name = var.name
 
@@ -90,15 +79,13 @@ resource "aws_iam_role_policy_attachment" "lambda_logs" {
 }
 
 resource "aws_lambda_function" "registration" {
-  filename         = local.registration_path
-  source_code_hash = data.archive_file.lambda_registration_zip.output_base64sha256
-  function_name    = var.name
-  role             = aws_iam_role.registration.arn
-  handler          = "lambda-registrator"
-  runtime          = "go1.x"
-  timeout          = var.timeout
-  layers           = []
-  tags             = {}
+  image_uri     = var.ecr_image_uri
+  package_type  = "Image"
+  function_name = var.name
+  role          = aws_iam_role.registration.arn
+  timeout       = var.timeout
+  layers        = []
+  tags          = {}
   environment {
     variables = merge(
       {

--- a/modules/lambda-registrator/variables.tf
+++ b/modules/lambda-registrator/variables.tf
@@ -43,3 +43,9 @@ variable "timeout" {
   type        = number
   default     = 30
 }
+
+variable "ecr_image_uri" {
+  description = "lambda-registrator Docker image."
+  type        = string
+  // TODO add a default when we publish this somewhere.
+}


### PR DESCRIPTION
I tested this out by running `terraform apply` in `./examples/simple` and ensuring that running `sh ./invoke.sh` still succeeds.