### PR TITLE
Refactor upserts that end up deleting Consul services

### DIFF
--- a/lambda-registrator/delete_event.go
+++ b/lambda-registrator/delete_event.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/consul/api"
 )
 
@@ -50,4 +52,9 @@ func (e DeleteEvent) writeOptions() *api.WriteOptions {
 	}
 
 	return writeOptions
+}
+
+func (e DeleteEvent) AddAlias(alias string) DeleteEvent {
+	e.ServiceName = fmt.Sprintf("%s-%s", e.ServiceName, alias)
+	return e
 }

--- a/lambda-registrator/environment_test.go
+++ b/lambda-registrator/environment_test.go
@@ -163,12 +163,13 @@ func mockEnvironment(lambdaClient lambdaiface.LambdaAPI, consulClient *api.Clien
 	}
 }
 
-type UpsertEventPlusAliases struct {
+type UpsertEventPlusMeta struct {
 	UpsertEvent
-	Aliases []string
+	Aliases       []string
+	CreateService bool
 }
 
-func mockLambdaClient(events ...UpsertEventPlusAliases) LambdaClient {
+func mockLambdaClient(events ...UpsertEventPlusMeta) LambdaClient {
 	functions := make(map[string]*lambda.GetFunctionOutput)
 	tags := make(map[string]*lambda.ListTagsOutput)
 	for _, event := range events {

--- a/lambda-registrator/event_test.go
+++ b/lambda-registrator/event_test.go
@@ -57,7 +57,6 @@ func TestUpsertAndDelete(t *testing.T) {
 
 	for n, c := range cases {
 		upsertEvent := UpsertEvent{
-			CreateService:      true,
 			PayloadPassthrough: true,
 			ServiceName:        serviceName,
 			ARN:                "arn",
@@ -71,16 +70,6 @@ func TestUpsertAndDelete(t *testing.T) {
 				require.NoError(t, err)
 
 				assertConsulState(t, consulClient, env, upsertEvent, 1)
-			})
-
-			t.Run("Disabling the service with meta", func(t *testing.T) {
-				upsertEvent2 := upsertEvent
-				upsertEvent2.CreateService = false
-
-				err := upsertEvent2.Reconcile(env)
-				require.NoError(t, err)
-
-				assertConsulState(t, consulClient, env, upsertEvent2, 0)
 			})
 
 			t.Run("Enabling the service with meta", func(t *testing.T) {


### PR DESCRIPTION
This is confusing so this uses the delete event instead.

Context: https://github.com/hashicorp/terraform-aws-consul-lambda-registrator/pull/4#discussion_r867021856