### PR TITLE
Use ECR Pull Through Cache

### DIFF
--- a/.github/workflows/bin-ci.yml
+++ b/.github/workflows/bin-ci.yml
@@ -33,8 +33,8 @@ jobs:
     strategy:
       matrix:
         consul-version:
-        - 1.12.0
-        - 1.12.0+ent
+        - 1.12.1
+        - 1.12.1+ent
     defaults:
       run:
         working-directory: ./consul-lambda-registrator

--- a/test/acceptance/setup-terraform/ecr.tf
+++ b/test/acceptance/setup-terraform/ecr.tf
@@ -26,11 +26,3 @@ resource "null_resource" "push-lambda-registrator-to-ecr" {
     aws_ecr_repository.lambda-registrator
   ]
 }
-
-data "aws_ecr_image" "lambda-registrator" {
-  depends_on = [
-    null_resource.push-lambda-registrator-to-ecr
-  ]
-  repository_name = local.ecr_repository_name
-  image_tag       = local.ecr_image_tag
-}

--- a/test/acceptance/tests/basic_test.go
+++ b/test/acceptance/tests/basic_test.go
@@ -44,7 +44,7 @@ func TestBasic(t *testing.T) {
 			namespace := ""
 			partition := ""
 			queryString := ""
-			tfVars["consul_image"] = "ghcr.io/erichaberkorn/consul:lambda-demo"
+			tfVars["consul_image"] = "public.ecr.aws/hashicorp/consul:1.12.1"
 
 			if c.enterprise {
 				tfVars["consul_license"] = os.Getenv("CONSUL_LICENSE")
@@ -53,7 +53,7 @@ func TestBasic(t *testing.T) {
 				tfVars["consul_namespace"] = namespace
 				tfVars["consul_partition"] = partition
 				queryString = fmt.Sprintf("?partition=%s&ns=%s", partition, namespace)
-				tfVars["consul_image"] = "ghcr.io/erichaberkorn/consul:lambda-demo-enterprise"
+				tfVars["consul_image"] = "public.ecr.aws/hashicorp/consul:1.12.1"
 			}
 
 			setupSuffix := tfVars["suffix"]


### PR DESCRIPTION
- Lambdas can only use private ECR images in the same region as the Lambda. By using pull through cache we can work around this limitation. Our acceptance tests are still using a private ECR image because public images require additional permissions.
- Now that 1.12.1 was released we don't need to use a customer container image.