### PR TITLE
Try to fix the sign workflow

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -73,6 +73,7 @@ event "security-scan-containers" {
 }
 
 event "sign" {
+  depends = ["security-scan-containers"]
   action "sign" {
     organization = "hashicorp"
     repository = "crt-workflows-common"


### PR DESCRIPTION
This matches [consul-ecs](https://github.com/hashicorp/consul-ecs/blob/main/.release/ci.hcl#L73). I'm hoping this is what is stopping the sign step from running.

After this, the diff between .release/ci.hcl on the branches is:
```diff
3c3
< project "terraform-aws-consul-lambda-registrator" {
---
> project "consul-ecs" {
11,15c11,12
<     repository = "terraform-aws-consul-lambda-registrator"
<     release_branches = [
<       "main",
<       "release/0.1.x",
<     ]
---
>     repository = "consul-ecs"
>     release_branches = ["main"]
28c25
<     repository = "terraform-aws-consul-lambda-registrator"
---
>     repository = "consul-ecs"
```