### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Changes proposed in this PR:
+-
+-
+
+## How I've tested this PR:
+
+## How I expect reviewers to test this PR:
+
+## Checklist:
+- [ ] Tests added
+- [ ] CHANGELOG entry added 
+
+    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
+    [Changelog entries should use present tense, e.g. "Add support for..."]::


### PR DESCRIPTION
## Changes proposed in this PR:
This PR adds a pull request template to the repo. The template is the same one used for the ECS repos.

## How I've tested this PR:
:eyes: 

## How I expect reviewers to test this PR:
:eyes:

## Checklist:
- [x] ~Tests added~ N/A
- [x] ~CHANGELOG entry added~ N/A 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::