### PR TITLE
update lambda-registrator module

### DIFF
--- a/consul-lambda-registrator/delete_event.go
+++ b/consul-lambda-registrator/delete_event.go
@@ -57,7 +57,7 @@ func (env Environment) deleteTLSData(e DeleteEvent) error {
 
 	// TODO: do we need to pass a context in here?.. like from the lambda entrypoint
 	// so that this call can be canceled if necessary.
-	return env.Store.Delete(context.Background(), fmt.Sprintf("%s%s", env.ExtensionDataPath, e.ExtensionPath()))
+	return env.Store.Delete(context.Background(), fmt.Sprintf("%s%s", env.ExtensionDataPrefix, e.ExtensionPath()))
 }
 
 func (e DeleteEvent) writeOptions() *api.WriteOptions {

--- a/consul-lambda-registrator/environment.go
+++ b/consul-lambda-registrator/environment.go
@@ -45,8 +45,8 @@ type Config struct {
 	// ConsulHTTPToken is the path to the Consul HTTP token in Parameter Store.
 	ConsulHTTPTokenPath string `envconfig:"CONSUL_HTTP_TOKEN_PATH"`
 
-	// ExtensionDataPath is the path in Parameter Store where extension data will be written.
-	ExtensionDataPath string `envconfig:"EXTENSION_DATA_PATH"`
+	// ExtensionDataPrefix is the path in Parameter Store where extension data will be written.
+	ExtensionDataPrefix string `envconfig:"CONSUL_EXTENSION_DATA_PREFIX"`
 
 	// PageSize is the maximum number of Lambda functions per page when querying the Lambda API.
 	PageSize int `envconfig:"PAGE_SIZE" default:"50"`
@@ -143,7 +143,7 @@ func SetupEnvironment(ctx context.Context) (Environment, error) {
 // IsManagingTLS indicates whether the Environment is configured to retrieve mTLS data from Consul and
 // write it to the parameter store.
 func (e Environment) IsManagingTLS() bool {
-	return len(e.ExtensionDataPath) > 0
+	return len(e.ExtensionDataPrefix) > 0
 }
 
 func setConsulCACert(ctx context.Context, store ParamStore, key string) error {

--- a/consul-lambda-registrator/environment_test.go
+++ b/consul-lambda-registrator/environment_test.go
@@ -57,7 +57,7 @@ func TestSetupEnvironment(t *testing.T) {
 	require.Equal(t, envVars[awsRegionEnvironment], env.Region)
 	require.Equal(t, envVars[datacenterEnvironment], env.Datacenter)
 	require.Equal(t, envVars[logLevelEnvironment], env.LogLevel)
-	require.Equal(t, envVars[extensionPathEnvironment], env.ExtensionDataPath)
+	require.Equal(t, envVars[extensionPathEnvironment], env.ExtensionDataPrefix)
 	require.NotNil(t, env.Lambda)
 	require.NotNil(t, env.ConsulClient)
 	require.NotNil(t, env.Logger)

--- a/consul-lambda-registrator/environment_test.go
+++ b/consul-lambda-registrator/environment_test.go
@@ -25,7 +25,7 @@ const (
 	logLevelEnvironment      string = "LOG_LEVEL"
 	consulCAPathEnvironment  string = "CONSUL_CACERT_PATH"
 	consulHTTPTokenPath      string = "CONSUL_HTTP_TOKEN_PATH"
-	extensionPathEnvironment string = "EXTENSION_DATA_PATH"
+	extensionPathEnvironment string = "CONSUL_EXTENSION_DATA_PREFIX"
 )
 
 func TestSetupEnvironment(t *testing.T) {

--- a/consul-lambda-registrator/upsert_event.go
+++ b/consul-lambda-registrator/upsert_event.go
@@ -133,7 +133,7 @@ func (env Environment) upsertTLSData(e UpsertEvent) error {
 		service.Namespace = e.EnterpriseMeta.Namespace
 		service.Partition = e.EnterpriseMeta.Partition
 	}
-	path := fmt.Sprintf("%s%s", env.ExtensionDataPath, service.ExtensionPath())
+	path := fmt.Sprintf("%s%s", env.ExtensionDataPrefix, service.ExtensionPath())
 
 	// TODO: do we need to pass a context in here?.. like from the lambda entrypoint
 	// so that this call can be canceled if necessary.

--- a/modules/lambda-registrator/variables.tf
+++ b/modules/lambda-registrator/variables.tf
@@ -8,6 +8,12 @@ variable "consul_http_addr" {
   type        = string
 }
 
+variable "consul_datacenter" {
+  description = "The Consul datacenter that the Lambda registrator is part of."
+  type        = string
+  default     = ""
+}
+
 variable "consul_ca_cert_path" {
   description = "The Parameter Store path containing the Consul server CA certificate."
   type        = string
@@ -16,6 +22,12 @@ variable "consul_ca_cert_path" {
 
 variable "consul_http_token_path" {
   description = "The Parameter Store path containing the Consul ACL token."
+  type        = string
+  default     = ""
+}
+
+variable "consul_extension_data_prefix" {
+  description = "The path within Parameter Store where Lambda registrator will write the Consul Lambda extension data. If this is unset, Lambda registrator will not write Consul data to Parameter Store."
   type        = string
   default     = ""
 }
@@ -77,4 +89,10 @@ variable "security_group_ids" {
   description = "List of security group IDs associated with Lambda registrator"
   type        = list(string)
   default     = []
+}
+
+variable "tags" {
+  description = "Additional tags to set on the Lambda registrator."
+  type        = map(string)
+  default     = {}
 }


### PR DESCRIPTION
## Changes proposed in this PR:
- This PR introduces the updates to the Lambda registrator TF module for injecting the configuration to update parameter store with the Consul-Lambda extension data.
- It also fixes a typo in the Lambda registrator configuration for the extension data. `EXTENSION_DATA_PATH` => `EXTENSION_DATA_PREFIX`

## How I've tested this PR:
- Unit tests
- Manual tests

## How I expect reviewers to test this PR:
:eyes:

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::