### PR TITLE
Publish Lambda Registrator Dev Image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,3 +141,43 @@ jobs:
           dev_tags: |
             hashicorppreview/${{ env.REG_NAME }}:${{ env.version }}
             docker.io/hashicorppreview/${{ env.REG_NAME }}:${{ env.version }}
+
+  upload-dev-docker:
+    name: Upload dev image (hashicorpdev/consul-lambda-registrator:<commit>)
+    environment: dockerhub/hashicorpdev
+    needs:
+      - get-product-version
+      - build-docker-default
+    runs-on: ubuntu-latest
+    env:
+      repo: ${{ github.event.repository.name }}
+      version: ${{ needs.get-product-version.outputs.product-version }}
+      arch: amd64
+      target: release-default
+      git-short-sha: ${{ needs.get-product-version.outputs.git-short-sha }}
+    steps:
+      - name: Download image artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.repo }}_${{ env.target }}_linux_${{ env.arch }}_${{ env.version }}_${{ github.sha }}.docker.dev.tar
+      - name: Docker push
+        shell: bash
+        run: |
+          TAG=hashicorpdev/${{ env.REG_NAME }}:${{ env.git-short-sha }}
+          echo "==> Load docker image from tar archive"
+          docker load -i "${{ env.repo }}_${{ env.target }}_linux_${{ env.arch }}_${{ env.version }}_${{ github.sha }}.docker.dev.tar"
+          echo "==> Tag docker image $TAG"
+          docker tag "hashicorppreview/${{ env.REG_NAME }}:${{ env.version }}" "$TAG"
+          echo "==> Docker login"
+          echo ${{ secrets.DOCKER_PASS }} | docker login -u=${{ secrets.DOCKER_USER }} --password-stdin
+          echo "==> Push docker image $TAG"
+          docker push "$TAG"
+      - name: Docker push (latest)
+        shell: bash
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          TAG=hashicorpdev/${{ env.REG_NAME }}:latest
+          echo "==> Tag docker image $TAG as :latest"
+          docker tag "hashicorpdev/${{ env.REG_NAME }}:${{ env.git-short-sha }}" "$TAG"
+          echo "==> Push docker image $TAG"
+          docker push "$TAG"


### PR DESCRIPTION
## Changes proposed in this PR:
This PR updates the CI build to publish the development version of the `consul-lambda-registrator` image to the `hashicorpdev` docker repo.

## How I've tested this PR:
- Ran the pipeline and confirmed that the image was pushed to `hashicorpdev/consul-lambda-registrator`
- `docker pull hashicorpdev/consul-lambda-registrator:eac4309`

## How I expect reviewers to test this PR:
:eyes: 

## Checklist:
- [x] ~Tests added~ N/A
- [x] ~CHANGELOG entry added~ N/A

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::