### PR TITLE
Updates for enterprise cases

### DIFF
--- a/consul-lambda/consul-lambda-registrator/delete_event.go
+++ b/consul-lambda/consul-lambda-registrator/delete_event.go
@@ -55,9 +55,19 @@ func (env Environment) deleteTLSData(e DeleteEvent) error {
 
 	env.Logger.Debug("deleting mTLS data", "service", e.Name)
 
+	// Create the info for this service
+	service := structs.Service{
+		Name:       e.Name,
+		Datacenter: e.Datacenter,
+	}
+	if e.EnterpriseMeta != nil {
+		service.EnterpriseMeta = e.EnterpriseMeta
+	}
+
 	// TODO: do we need to pass a context in here?.. like from the lambda entrypoint
 	// so that this call can be canceled if necessary.
-	return env.Store.Delete(context.Background(), fmt.Sprintf("%s%s", env.ExtensionDataPrefix, e.ExtensionPath()))
+	return env.Store.Delete(context.Background(),
+		fmt.Sprintf("%s%s", env.ExtensionDataPrefix, service.ExtensionPath()))
 }
 
 func (e DeleteEvent) writeOptions() *api.WriteOptions {

--- a/consul-lambda/consul-lambda-registrator/environment.go
+++ b/consul-lambda/consul-lambda-registrator/environment.go
@@ -146,8 +146,7 @@ func (e Environment) IsManagingTLS() bool {
 	return len(e.ExtensionDataPrefix) > 0
 }
 
-func setConsulCACert(ctx context.Context, store ParamStore, key string) error {
-	path := os.Getenv(key)
+func setConsulCACert(ctx context.Context, store ParamStore, path string) error {
 	if path == "" {
 		return nil
 	}
@@ -165,8 +164,7 @@ func setConsulCACert(ctx context.Context, store ParamStore, key string) error {
 	return os.Setenv("CONSUL_CACERT", caCertPath)
 }
 
-func setConsulHTTPToken(ctx context.Context, store ParamStore, key string) error {
-	path := os.Getenv(key)
+func setConsulHTTPToken(ctx context.Context, store ParamStore, path string) error {
 	if path == "" {
 		return nil
 	}

--- a/consul-lambda/consul-lambda-registrator/environment_test.go
+++ b/consul-lambda/consul-lambda-registrator/environment_test.go
@@ -68,7 +68,6 @@ func TestSetupEnvironment(t *testing.T) {
 func TestSetConsulCACert(t *testing.T) {
 	ctx := context.Background()
 	unsetEverything := func() {
-		os.Unsetenv(consulCAPathEnvironment)
 		os.Unsetenv("CONSUL_CACERT")
 		os.Remove(caCertPath)
 	}
@@ -76,7 +75,7 @@ func TestSetConsulCACert(t *testing.T) {
 	t.Run("Without the environment variable set", func(t *testing.T) {
 		t.Cleanup(unsetEverything)
 		ssmClient := mockSSMClient(map[string]string{})
-		err := setConsulCACert(ctx, ssmClient, consulCAPathEnvironment)
+		err := setConsulCACert(ctx, ssmClient, "")
 		require.NoError(t, err)
 		_, err = os.Stat(caCertPath)
 		require.Error(t, err)
@@ -85,9 +84,8 @@ func TestSetConsulCACert(t *testing.T) {
 
 	t.Run("With a path that isn't in parameter store", func(t *testing.T) {
 		t.Cleanup(unsetEverything)
-		os.Setenv(consulCAPathEnvironment, "not/real")
 		ssmClient := mockSSMClient(map[string]string{})
-		err := setConsulCACert(ctx, ssmClient, consulCAPathEnvironment)
+		err := setConsulCACert(ctx, ssmClient, "not/real")
 		require.Error(t, err)
 		_, err = os.Stat(caCertPath)
 		require.Error(t, err)
@@ -96,9 +94,8 @@ func TestSetConsulCACert(t *testing.T) {
 
 	t.Run("With a path is in parameter store", func(t *testing.T) {
 		t.Cleanup(unsetEverything)
-		os.Setenv(consulCAPathEnvironment, "real")
 		ssmClient := mockSSMClient(map[string]string{"real": "value"})
-		err := setConsulCACert(ctx, ssmClient, consulCAPathEnvironment)
+		err := setConsulCACert(ctx, ssmClient, "real")
 		require.NoError(t, err)
 		buf, err := os.ReadFile(caCertPath)
 		require.NoError(t, err)
@@ -109,7 +106,6 @@ func TestSetConsulCACert(t *testing.T) {
 func TestSetConsulHTTPToken(t *testing.T) {
 	ctx := context.Background()
 	unsetEverything := func() {
-		os.Unsetenv(consulHTTPTokenPath)
 		os.Unsetenv("CONSUL_HTTP_TOKEN")
 		os.Remove(caCertPath)
 	}
@@ -117,25 +113,23 @@ func TestSetConsulHTTPToken(t *testing.T) {
 	t.Run("Without the environment variable set", func(t *testing.T) {
 		t.Cleanup(unsetEverything)
 		ssmClient := mockSSMClient(map[string]string{})
-		err := setConsulHTTPToken(ctx, ssmClient, consulHTTPTokenPath)
+		err := setConsulHTTPToken(ctx, ssmClient, "")
 		require.NoError(t, err)
 		require.Equal(t, "", os.Getenv("CONSUL_HTTP_TOKEN"))
 	})
 
 	t.Run("With a path that isn't in parameter store", func(t *testing.T) {
 		t.Cleanup(unsetEverything)
-		os.Setenv(consulHTTPTokenPath, "not/real")
 		ssmClient := mockSSMClient(map[string]string{})
-		err := setConsulHTTPToken(ctx, ssmClient, consulHTTPTokenPath)
+		err := setConsulHTTPToken(ctx, ssmClient, "not/real")
 		require.Error(t, err)
 		require.Equal(t, "", os.Getenv("CONSUL_HTTP_TOKEN"))
 	})
 
 	t.Run("With a path is in parameter store", func(t *testing.T) {
 		t.Cleanup(unsetEverything)
-		os.Setenv(consulHTTPTokenPath, "real")
 		ssmClient := mockSSMClient(map[string]string{"real": "value"})
-		err := setConsulHTTPToken(ctx, ssmClient, consulHTTPTokenPath)
+		err := setConsulHTTPToken(ctx, ssmClient, "real")
 		require.NoError(t, err)
 		require.Equal(t, "value", os.Getenv("CONSUL_HTTP_TOKEN"))
 	})

--- a/consul-lambda/consul-lambda-registrator/upsert_event.go
+++ b/consul-lambda/consul-lambda-registrator/upsert_event.go
@@ -130,8 +130,7 @@ func (env Environment) upsertTLSData(e UpsertEvent) error {
 		TrustDomain: caRootList.TrustDomain,
 	}
 	if e.EnterpriseMeta != nil {
-		service.Namespace = e.EnterpriseMeta.Namespace
-		service.Partition = e.EnterpriseMeta.Partition
+		service.EnterpriseMeta = e.EnterpriseMeta
 	}
 	path := fmt.Sprintf("%s%s", env.ExtensionDataPrefix, service.ExtensionPath())
 


### PR DESCRIPTION
## Changes proposed in this PR:
This PR updates Lambda registrator's handling of admin partition and namespaces for Consul Enterprise. The primary change is moving from pointer-based to value-based map keys for `EnterpriseMeta`. This is necessary because the `EnterpriseMeta` keys were initialized separately in two different parts of the code and later compared. The comparisons fail when the pointers are different even when the values are the same (i.e., same admin partition/namespace).
 
## How I've tested this PR:
- Unit tests
- Acceptance tests (performed on the `cthain/update-acceptance-tests` branch)

## How I expect reviewers to test this PR:
:eyes: 

## Checklist:
- [x] Tests added
- [x] ~CHANGELOG entry added~ N/A 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::