### PR TITLE
Update the URL for the consul-lambda-extension

### DIFF
--- a/examples/lambda/README.md
+++ b/examples/lambda/README.md
@@ -110,7 +110,7 @@ This example Terraform workspace will use the zip package to deploy the `consul-
 add it to the `lambda-app-2` function so that it can call services within the Consul service mesh.
 
 ```shell
-curl -o consul-lambda-extension.zip https://releases.hashicorp.com/consul-lambda/${VERSION}/consul-lambda-extension_${VERSION}_linux_amd64.zip
+curl -o consul-lambda-extension.zip https://releases.hashicorp.com/consul-lambda-extension/${VERSION}/consul-lambda-extension_${VERSION}_linux_amd64.zip
 ```
 
 ## Build the example Lambda function


### PR DESCRIPTION
## Changes proposed in this PR:
This PR corrects the URL path to the `consul-lambda-extension` on the HashiCorp releases website.
I ran all the steps in the example to confirm it was working for the `v0.1.0-beta2` release and noticed that this path was incorrect. (Otherwise everything worked as documented :+1: )

## How I've tested this PR:
Ran the example.

## How I expect reviewers to test this PR:
:eyes: 

## Checklist:
- [x] ~Tests added~ N/A
- [x] ~CHANGELOG entry added~ N/A

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::