### PR TITLE
Lambda Reg UX changes to simplify for users

### DIFF
--- a/examples/lambda/README.md
+++ b/examples/lambda/README.md
@@ -51,57 +51,16 @@ cd terraform-aws-consul-lambda/examples/lambda
 git checkout v${VERSION}
 ```
 
-## Set your AWS account ID and region
+## Set your AWS region
 
-Subsequent steps require knowledge of your AWS account ID and the AWS region that you want to deploy the example resources to.
+Subsequent steps require knowledge of the AWS region that you want to deploy the example resources to.
 Export these values to environment variables using the commands below.
-Replace `<account_id>` and `<region>` with your AWS account ID and region, respectively.
+Replace  `<region>` with your AWS region.
 
 ```shell
-export AWS_ACCOUNT_ID=<account_id>
 export AWS_REGION=<region>
 ```
 
-## Publish `consul-lambda-registrator`
-
-In this section you will pull the `consul-lambda-registrator` image from the AWS Public ECR Gallery and publish it to a private ECR repository using `docker`. This is required because AWS Lambda functions must use images from a private ECR repository. They are not able to use images from the Public ECR Gallery.
-
-### Pull `consul-lambda-registrator`
-
-Use the following command to pull the `consul-lambda-registrator` from the AWS Public ECR to your local machine.
-
-```shell
-docker pull public.ecr.aws/hashicorp/consul-lambda-registrator:${VERSION}
-```
-
-### Log in to AWS ECR
-
-```shell
-aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com
-```
-
-### Create a private ECR repository
-
-Use the following command to create a private ECR repository for `consul-lambda-registrator`.
-
-```shell
-aws ecr create-repository \
-  --repository-name consul-lambda-registrator \
-  --image-scanning-configuration scanOnPush=true \
-  --region ${AWS_REGION}
-```
-
-### Push `consul-lambda-registrator`
-
-Use the following commands to push the `consul-lambda-registrator` image to the private ECR repository you created in the previous step.
-
-```shell
-docker tag \
-  public.ecr.aws/hashicorp/consul-lambda-registrator:${VERSION} \
-  ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/consul-lambda-registrator:${VERSION}
-
-docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/consul-lambda-registrator:${VERSION}
-```
 
 ## Download the `consul-lambda-extension`
 
@@ -119,7 +78,7 @@ This step builds and packages the function that will be deployed to AWS Lambda.
 This Lambda function is used as the source for both `lambda-app-1` and `lambda-app-2`.
 
 ```shell
-(cd src/lambda && GOOS=linux go build -o main && zip function.zip main)
+(cd src/lambda && GOOS=linux GOARCH=amd64 go build -o main && zip function.zip main)
 ```
 
 ## Get your IP address
@@ -139,7 +98,6 @@ terraform init
 terraform apply \
   -var "name=${USER}" \
   -var "region=${AWS_REGION}" \
-  -var "ecr_image_uri=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/consul-lambda-registrator:${VERSION}" \
   -var "ingress_cidrs=[\"${MY_IP}\"]"
 ```
 
@@ -261,7 +219,6 @@ Use the following command to clean up the resources managed by Terraform.
 terraform destroy \
   -var "name=${USER}" \
   -var "region=${AWS_REGION}" \
-  -var "ecr_image_uri=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/consul-lambda-registrator:${VERSION}" \
   -var "ingress_cidrs=[\"${MY_IP}\"]"
 ```
 

--- a/examples/lambda/registrator.tf
+++ b/examples/lambda/registrator.tf
@@ -1,10 +1,10 @@
 module "consul_lambda_registrator" {
   source                       = "../../modules/lambda-registrator"
   name                         = "${var.name}-lambda-registrator"
-  ecr_image_uri                = var.ecr_image_uri
   consul_http_addr             = "http://${module.dev_consul_server.server_dns}:8500"
   consul_extension_data_prefix = "/${var.name}"
   subnet_ids                   = module.vpc.private_subnets
   security_group_ids           = [module.vpc.default_security_group_id]
   sync_frequency_in_minutes    = 1
+  pull_through                 = false
 }

--- a/examples/lambda/variables.tf
+++ b/examples/lambda/variables.tf
@@ -3,9 +3,10 @@ variable "name" {
   type        = string
 }
 
-variable "ecr_image_uri" {
-  description = "The private ECR image URI for consul-lambda-registrator."
+variable "lambda_registrator_image" {
+  description = "The Consul Lambda Registrator image for consul-lambda-registrator."
   type        = string
+  default = "public.ecr.aws/hashicorp/consul-lambda-registrator:0.1.0-beta2"
 }
 
 variable "region" {

--- a/modules/lambda-registrator/main.tf
+++ b/modules/lambda-registrator/main.tf
@@ -6,7 +6,12 @@ locals {
   }] : []
   cron_key          = "${var.name}-cron"
   lambda_events_key = "${var.name}-lambda_events"
+  image_tag     = split(":", var.consul_lambda_registrator_image)[1]
+  ecr_image_uri = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${var.region}.amazonaws.com/${var.private_repo_name}:${local.image_tag}"
+  //See comment in line 157 for explanation
+//  ecr_image_uri_pull-through = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${var.region}.amazonaws.com/ecr-public/hashicorp/${var.private_repo_name}:${local.image_tag}"
 }
+data "aws_caller_identity" "current" {}
 
 resource "aws_iam_role" "registration" {
   name = var.name
@@ -124,8 +129,54 @@ resource "aws_iam_role_policy_attachment" "lambda_logs" {
   policy_arn = aws_iam_policy.policy.arn
 }
 
+resource "aws_ecr_repository" "lambda-registrator" {
+  name = var.private_repo_name
+  force_delete = true
+}
+
+resource "null_resource" "pull_and_republish_ecr_image" {
+  count = var.pull_through ? 0 : 1
+  triggers = {
+    always_run = timestamp()
+  }
+
+  provisioner "local-exec" {
+    command = <<EOF
+    aws ecr get-login-password --region ${var.region} | docker login --username AWS --password-stdin ${data.aws_caller_identity.current.account_id}.dkr.ecr.${var.region}.amazonaws.com
+    docker pull ${var.consul_lambda_registrator_image}
+    docker tag ${var.consul_lambda_registrator_image}  ${local.ecr_image_uri}
+    docker push ${local.ecr_image_uri}
+    EOF
+  }
+
+  depends_on = [
+    aws_ecr_repository.lambda-registrator
+  ]
+}
+
+// Was able to get the pull through cache running via command line using the same aws-docker login as in line 145 and doing a modified pull using ecr pull-through variable in locals above
+// through the command line - but unable to replicate that behavior here. Paul was paired with me when we made this breakthrough so may be valuable to ping him for clearer explanation.
+// Commenting out below resource for now.
+#resource "null_resource" "ecr_pull_through_cache" {
+#  count = var.pull_through ? 1 : 0
+#  triggers = {
+#    always_run = timestamp()
+#  }
+#
+#  provisioner "local-exec" {
+#    command = <<EOF
+#    aws ecr create-pull-through-cache-rule \
+#     --ecr-repository-prefix ecr-public \
+#     --upstream-registry-url public.ecr.aws \
+#     --region ${var.region}
+#    EOF
+#  }
+  //Need to find a way to force delete the created pull through rule, otherwise error will be thrown if this is run multiple times sans delete
+  //since pull through rule already exists from previous apply
+#}
+
 resource "aws_lambda_function" "registration" {
-  image_uri                      = var.ecr_image_uri
+  image_uri                      = local.ecr_image_uri
   package_type                   = "Image"
   function_name                  = var.name
   role                           = aws_iam_role.registration.arn
@@ -162,6 +213,11 @@ resource "aws_lambda_function" "registration" {
       security_group_ids = vpc_config.value["security_group_ids"]
     }
   }
+
+  depends_on = [
+    null_resource.pull_and_republish_ecr_image
+  ]
+  //Once pull through is properly configured, need to add null_resource.ecr_pull_through_cache into depends_on array
 }
 
 module "eventbridge" {

--- a/modules/lambda-registrator/variables.tf
+++ b/modules/lambda-registrator/variables.tf
@@ -62,16 +62,11 @@ variable "reserved_concurrent_executions" {
   default     = -1
 }
 
-variable "ecr_image_uri" {
-  description = <<-EOT
-  The ECR image URI for consul-lambda-registrator. The image must be in the
-  same AWS region and in a private ECR repository. Due to these constraints,
-  the public ECR images (https://gallery.ecr.aws/hashicorp/consul-lambda-registrator)
-  cannot be used directly. We recommend either creating and using a new ECR
-  repository or configuring pull through cache rules (https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache.html).
-  EOT
-  type        = string
-}
+#variable "image_uri" {
+#  description = "The image URI for consul-lambda-registrator."
+#  type        = string
+#  default     = "public.ecr.aws/hashicorp/consul-lambda-registrator:0.1.0-beta2"
+#}
 
 variable "sync_frequency_in_minutes" {
   description = "The interval EventBridge is configured to trigger full synchronizations."
@@ -95,4 +90,28 @@ variable "tags" {
   description = "Additional tags to set on the Lambda registrator."
   type        = map(string)
   default     = {}
+}
+variable "region" {
+  type = string
+  description = "AWS region for private repository"
+  default     = "us-east-2"
+}
+
+variable "private_repo_name" {
+  description = "The name of the repository to republish the ECR image if one exists. If no name is passed, it is assumed that no repository exists and one needs to be created."
+  type = string
+  default = "consul-lambda-registrator"
+}
+
+variable "pull_through" {
+  description = "Flag to determine if a pull-through cache method will be used to obtain the appropriate ECR image"
+  type = bool
+  default = false
+}
+
+
+variable "consul_lambda_registrator_image"{
+  description = "The Lambda registrator image to be used, either the latest L.R. image or a user specified prior version"
+  type = string
+  default = "public.ecr.aws/hashicorp/consul-lambda-registrator:0.1.0-beta2"
 }


### PR DESCRIPTION
## Changes proposed in this PR:
- Modify Lambda Reg to create a terraform module that either creates a new private ECR repo and uses null_resource to republish a public image to it
- Need to solve pull through solution

## How I've tested this PR:
- Ran the code to see if ECR private repo and Lambda function was created successfully

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::