### PR TITLE
Display Consul logo for the consul-lambda module on the Terriform registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1>
-  <img src="./_docs/logo.svg" align="left" height="46px" alt="Consul logo"/>
+  <img src="https://raw.githubusercontent.com/hashicorp/terraform-aws-consul-lambda/main/_docs/logo.svg" align="left" height="46px" alt="Consul logo"/>
   <span>Consul on AWS Lambda</span>
 </h1>
 


### PR DESCRIPTION
## Changes proposed in this PR:
The Consul logo does show up for the [`consul-lambda` module on the Terraform registry](https://registry.terraform.io/modules/hashicorp/consul-lambda/aws/0.1.0-beta2). This PR updates the link to the Consul logo in the README file to use the full raw github URL.

## How I've tested this PR:
:eyes:

## How I expect reviewers to test this PR:
:eyes:

## Checklist:
- [x] ~Tests added~ - N/a
- [x] ~CHANGELOG entry added~ - N/a

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::