### PR TITLE
Beta3 prep

### DIFF
--- a/.github/workflows/bin-ci.yml
+++ b/.github/workflows/bin-ci.yml
@@ -49,8 +49,8 @@ jobs:
     strategy:
       matrix:
         consul-version:
-        - 1.15.0
-        - 1.15.0+ent
+        - 1.15.1
+        - 1.15.1+ent
     needs:
       - get-go-version
     defaults:

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -8,7 +8,6 @@ on:
     branches:
       - 'main'
       - 'release/**'
-  workflow_dispatch:
 env:
   CONSUL_LICENSE: ${{ secrets.CONSUL_LICENSE }}
 jobs:

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - 'main'
       - 'release/**'
+  workflow_dispatch:
 env:
   CONSUL_LICENSE: ${{ secrets.CONSUL_LICENSE }}
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
-## UNRELEASED
+## 0.1.0-beta3 (Mar 16, 2023)
+
+BREAKING CHANGES
+* `EnvoyExtensions` configuration was released in Consul 1.15.0 and is now used to configure Lambda functions.
+  [[GH-51]](https://github.com/hashicorp/terraform-aws-consul-lambda/pull/51)
 
 FEATURES
-* Update minimum go version for project to 1.20 [[GH-1908](https://github.com/hashicorp/terraform-aws-consul-lambda/pull/54)]
+* Update minimum go version for project to 1.20 [[GH-1908]](https://github.com/hashicorp/terraform-aws-consul-lambda/pull/54)
 
 BUG FIXES:
 * Security:
-    * Upgrade to use Go 1.20.1 This resolves vulnerabilities [CVE-2022-41724](https://go.dev/issue/58001) in `crypto/tls` and [CVE-2022-41723](https://go.dev/issue/57855) in `net/http`. [[GH-1908](https://github.com/hashicorp/terraform-aws-consul-lambda/pull/54)]
+    * Upgrade to use Go 1.20.1 This resolves vulnerabilities [CVE-2022-41724](https://go.dev/issue/58001) in `crypto/tls` and [CVE-2022-41723](https://go.dev/issue/57855) in `net/http`. [[GH-1908]](https://github.com/hashicorp/terraform-aws-consul-lambda/pull/54)
 
 ## 0.1.0-beta2 (October 04, 2022)
 

--- a/test/acceptance/tests/basic_test.go
+++ b/test/acceptance/tests/basic_test.go
@@ -54,7 +54,7 @@ func TestBasic(t *testing.T) {
 			namespace := ""
 			partition := ""
 			queryString := ""
-			tfVars["consul_image"] = "public.ecr.aws/hashicorp/consul:1.15.0"
+			tfVars["consul_image"] = "public.ecr.aws/hashicorp/consul:1.15.1"
 
 			if c.enterprise {
 				tfVars["consul_license"] = os.Getenv("CONSUL_LICENSE")
@@ -64,7 +64,7 @@ func TestBasic(t *testing.T) {
 				tfVars["consul_namespace"] = namespace
 				tfVars["consul_partition"] = partition
 				queryString = fmt.Sprintf("?partition=%s&ns=%s", partition, namespace)
-				tfVars["consul_image"] = "public.ecr.aws/hashicorp/consul:1.15.0"
+				tfVars["consul_image"] = "public.ecr.aws/hashicorp/consul-enterprise:1.15.1-ent"
 			}
 
 			setupSuffix := tfVars["suffix"]

--- a/test/acceptance/tests/setup/consul.tf
+++ b/test/acceptance/tests/setup/consul.tf
@@ -23,7 +23,7 @@ module "dev_consul_server" {
   consul_image                = var.consul_image
   name                        = "${local.short_name}-consul-server"
   source                      = "hashicorp/consul-ecs/aws//modules/dev-server"
-  version                     = "0.5.2"
+  version                     = "0.6.0"
   ecs_cluster_arn             = var.ecs_cluster_arn
   subnet_ids                  = var.private_subnets
   vpc_id                      = var.vpc_id

--- a/test/acceptance/tests/setup/ecs.tf
+++ b/test/acceptance/tests/setup/ecs.tf
@@ -15,10 +15,13 @@ resource "aws_ecs_service" "test_client" {
 }
 
 module "test_client" {
-  source  = "hashicorp/consul-ecs/aws//modules/mesh-task"
-  version = "0.5.2"
-  family  = "test_client_${var.suffix}"
-  port    = "9090"
+  //TODO source  = "hashicorp/consul-ecs/aws//modules/mesh-task"
+  //TODO version = "0.6.0"
+  //TODO remove
+  consul_ecs_image = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
+  source           = "github.com/hashicorp/terraform-aws-consul-ecs//modules/mesh-task?ref=f118df6ca90fe5c07c4ae4e57de28a54a3263866"
+  family           = "test_client_${var.suffix}"
+  port             = "9090"
   container_definitions = [{
     name      = "basic"
     image     = "docker.mirror.hashicorp.services/nicholasjackson/fake-service:v0.21.0"
@@ -162,9 +165,11 @@ resource "aws_iam_role" "execution" {
 }
 
 module "acl_controller" {
-  count   = var.secure ? 1 : 0
-  source  = "hashicorp/consul-ecs/aws//modules/acl-controller"
-  version = "0.5.2"
+  count = var.secure ? 1 : 0
+  //TODO source  = "hashicorp/consul-ecs/aws//modules/acl-controller"
+  //TODO version = "0.5.2"
+  consul_ecs_image = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
+  source           = "github.com/hashicorp/terraform-aws-consul-ecs//modules/acl-controller?ref=f118df6ca90fe5c07c4ae4e57de28a54a3263866"
   log_configuration = {
     logDriver = "awslogs"
     options = {

--- a/test/acceptance/tests/setup/ecs.tf
+++ b/test/acceptance/tests/setup/ecs.tf
@@ -15,13 +15,10 @@ resource "aws_ecs_service" "test_client" {
 }
 
 module "test_client" {
-  //TODO source  = "hashicorp/consul-ecs/aws//modules/mesh-task"
-  //TODO version = "0.6.0"
-  //TODO remove
-  consul_ecs_image = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
-  source           = "github.com/hashicorp/terraform-aws-consul-ecs//modules/mesh-task?ref=839c2aebd4dc38e579297b823acadd71312d5e7c"
-  family           = "test_client_${var.suffix}"
-  port             = "9090"
+  source  = "hashicorp/consul-ecs/aws//modules/mesh-task"
+  version = "0.6.0"
+  family  = "test_client_${var.suffix}"
+  port    = "9090"
   container_definitions = [{
     name      = "basic"
     image     = "docker.mirror.hashicorp.services/nicholasjackson/fake-service:v0.21.0"
@@ -165,11 +162,9 @@ resource "aws_iam_role" "execution" {
 }
 
 module "acl_controller" {
-  count = var.secure ? 1 : 0
-  //TODO source  = "hashicorp/consul-ecs/aws//modules/acl-controller"
-  //TODO version = "0.5.2"
-  consul_ecs_image = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
-  source           = "github.com/hashicorp/terraform-aws-consul-ecs//modules/acl-controller?ref=839c2aebd4dc38e579297b823acadd71312d5e7c"
+  count   = var.secure ? 1 : 0
+  source  = "hashicorp/consul-ecs/aws//modules/acl-controller"
+  version = "0.6.0"
   log_configuration = {
     logDriver = "awslogs"
     options = {

--- a/test/acceptance/tests/setup/ecs.tf
+++ b/test/acceptance/tests/setup/ecs.tf
@@ -19,7 +19,7 @@ module "test_client" {
   //TODO version = "0.6.0"
   //TODO remove
   consul_ecs_image = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
-  source           = "github.com/hashicorp/terraform-aws-consul-ecs//modules/mesh-task?ref=f118df6ca90fe5c07c4ae4e57de28a54a3263866"
+  source           = "github.com/hashicorp/terraform-aws-consul-ecs//modules/mesh-task?ref=839c2aebd4dc38e579297b823acadd71312d5e7c"
   family           = "test_client_${var.suffix}"
   port             = "9090"
   container_definitions = [{
@@ -169,7 +169,7 @@ module "acl_controller" {
   //TODO source  = "hashicorp/consul-ecs/aws//modules/acl-controller"
   //TODO version = "0.5.2"
   consul_ecs_image = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
-  source           = "github.com/hashicorp/terraform-aws-consul-ecs//modules/acl-controller?ref=f118df6ca90fe5c07c4ae4e57de28a54a3263866"
+  source           = "github.com/hashicorp/terraform-aws-consul-ecs//modules/acl-controller?ref=839c2aebd4dc38e579297b823acadd71312d5e7c"
   log_configuration = {
     logDriver = "awslogs"
     options = {

--- a/test/acceptance/tests/setup/gateway.tf
+++ b/test/acceptance/tests/setup/gateway.tf
@@ -2,8 +2,11 @@
 # SPDX-License-Identifier: MPL-2.0
 
 module "mesh_gateway" {
-  source                        = "hashicorp/consul-ecs/aws//modules/gateway-task"
-  version                       = "0.5.2"
+  //TODO source                        = "hashicorp/consul-ecs/aws//modules/gateway-task"
+  //TODO version                       = "0.5.2"
+  consul_ecs_image = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
+  source           = "github.com/hashicorp/terraform-aws-consul-ecs//modules/gateway-task?ref=f118df6ca90fe5c07c4ae4e57de28a54a3263866"
+
   kind                          = "mesh-gateway"
   family                        = "mesh-gateway-${var.suffix}"
   ecs_cluster_arn               = var.ecs_cluster_arn

--- a/test/acceptance/tests/setup/gateway.tf
+++ b/test/acceptance/tests/setup/gateway.tf
@@ -5,7 +5,7 @@ module "mesh_gateway" {
   //TODO source                        = "hashicorp/consul-ecs/aws//modules/gateway-task"
   //TODO version                       = "0.5.2"
   consul_ecs_image = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
-  source           = "github.com/hashicorp/terraform-aws-consul-ecs//modules/gateway-task?ref=f118df6ca90fe5c07c4ae4e57de28a54a3263866"
+  source           = "github.com/hashicorp/terraform-aws-consul-ecs//modules/gateway-task?ref=839c2aebd4dc38e579297b823acadd71312d5e7c"
 
   kind                          = "mesh-gateway"
   family                        = "mesh-gateway-${var.suffix}"

--- a/test/acceptance/tests/setup/gateway.tf
+++ b/test/acceptance/tests/setup/gateway.tf
@@ -2,10 +2,8 @@
 # SPDX-License-Identifier: MPL-2.0
 
 module "mesh_gateway" {
-  //TODO source                        = "hashicorp/consul-ecs/aws//modules/gateway-task"
-  //TODO version                       = "0.5.2"
-  consul_ecs_image = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
-  source           = "github.com/hashicorp/terraform-aws-consul-ecs//modules/gateway-task?ref=839c2aebd4dc38e579297b823acadd71312d5e7c"
+  source  = "hashicorp/consul-ecs/aws//modules/gateway-task"
+  version = "0.6.0"
 
   kind                          = "mesh-gateway"
   family                        = "mesh-gateway-${var.suffix}"


### PR DESCRIPTION
## Changes proposed in this PR:
- Updates the changelog for the upcoming `0.1.0-beta3` release.
- Uses `consul-ecs v0.6.0` for acceptance testing with Consul 1.15.1

## How I've tested this PR:
- Unit tests
- Acceptance tests

## How I expect reviewers to test this PR:
:eyes: 

## Checklist:
- [x] ~Tests added~ N/A
- [x] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::