### PR TITLE
Pin EventBridge Terraform module version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## Unreleased
+## 0.1.0-beta4 (Apr 28, 2023)
+
+IMPROVEMENTS:
+* Pin the version of the `terraform-aws-modules/eventbridge/aws` module to v1.17.3. This ensures the selection of the eventbridge module is deterministic when using the `lambda-registrator` Terraform module.
+  [[GH-70]](https://github.com/hashicorp/terraform-aws-consul-lambda/pull/70)
 
 BUG FIXES:
 * Disable Cgo compilation for Lambda registrator and extension. Compiling without `CGO_ENABLED=0` on Go 1.20 [causes an issue](https://github.com/hashicorp/terraform-aws-consul-lambda/issues/57) that does not allow Lambda registrator or the Lambda extension to execute within the AWS Lambda runtime.

--- a/modules/lambda-registrator/main.tf
+++ b/modules/lambda-registrator/main.tf
@@ -168,7 +168,8 @@ resource "aws_lambda_function" "registration" {
 }
 
 module "eventbridge" {
-  source = "terraform-aws-modules/eventbridge/aws"
+  source  = "terraform-aws-modules/eventbridge/aws"
+  version = "1.17.3"
 
   create_bus = false
   role_name  = "${var.name}-eventbridge"


### PR DESCRIPTION
## Changes proposed in this PR:
The version of the `terraform-aws-modules/eventbridge/aws` module was not specified in the `lambda-registrator` Terraform module. Versions 2.0.0 and 2.1.0 of the eventbridge module were released today. These contain breaking changes requiring an incompatible and untested version of the `hashicorp/aws` Terraform provider (>= 4.64.0). During `terraform init` Terraform attempted to select the most recent version of the eventbridge module because the version was not specified, and this caused a version mismatch for the `aws` Terraform provider. This caused [the acceptance tests to fail](https://github.com/hashicorp/terraform-aws-consul-lambda/actions/runs/4831033334/jobs/8608129224).

This PR updates the `lambda-registrator` Terraform module to pin the version of the [AWS EventBridge module to v1.17.3](https://registry.terraform.io/modules/terraform-aws-modules/eventbridge/aws/1.17.3) so the selection of the module is deterministic.

It also updates the release in the CHANGELOG to match the beta4 version that will be released today.

## How I've tested this PR:
- Acceptance tests
- Lambda example

## How I expect reviewers to test this PR:
:eyes: 

## Checklist:
- [x] ~Tests added~ Not applicable
- [x] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::