### PR TITLE
Update Acceptance Test Workflow

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v1
+      uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
       with:
         terraform_version: v1.3.1
     - name: Validate
@@ -120,9 +120,6 @@ jobs:
       run: |
         mkdir -p "$TEST_RESULTS"
         gotestsum \
-          --rerun-fails=2 \
-          --rerun-fails-max-failures=2 \
-          --rerun-fails-report "$TEST_RESULTS/gotestsum-rerun-fails" \
           --packages "./..." \
           --junitfile "$TEST_RESULTS/gotestsum-report.xml" \
           --format standard-verbose -- \
@@ -132,11 +129,6 @@ jobs:
       with:
         name: acceptance-test-results
         path: ${{ env.TEST_RESULTS }}/gotestsum-report.xml
-    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-      if: always()
-      with:
-        name: acceptance-test-flakes
-        path: ${{ env.TEST_RESULTS }}/gotestsum-rerun-fails
     - name: terraform destroy
       if: always()
       run: |


### PR DESCRIPTION
## Changes proposed in this PR:
- Bump the version of the `setup-terraform` action to v2.0.3
- Remove acceptance test retries. The retries consume a bunch of extra time when a test fails and they rarely (if ever) fix a failed CI run.

This PR resolves https://github.com/hashicorp/terraform-aws-consul-lambda/issues/72

## How I've tested this PR:
CI:
- [Previous workflow runs reported warnings](https://github.com/hashicorp/terraform-aws-consul-lambda/actions/runs/4833138217).
- [Latest workflow run has no warnings](https://github.com/hashicorp/terraform-aws-consul-lambda/actions/runs/5005641189).

## How I expect reviewers to test this PR:
:eyes: 

## Checklist:
- [x] ~Tests added~ Not applicable
- [x] ~CHANGELOG entry added~ Not applicable

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::