### PR TITLE
Update SSM Set to allow for Advanced Tier Parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
+## Unreleased
+
+FEATURES
+* Add support for storing parameter values greater than 4 KB. The `lambda-registrator` module and source code have been updated to accept a configurable value for the [SSM parameter tier](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-advanced-parameters.html). This allows users to choose if they want to use the `Advanced` tier feature. Charges apply for the `Advanved` tier so if the tier is not expressly set to `Advanced`, then the `Standard` tier will be used. Using the `Advanced` tier allows for parameter values up to 8 KB. The Lambda-registrator Terraform module can be configured using the new `consul_extension_data_tier` variable.
+  [[GH-78]](https://github.com/hashicorp/terraform-aws-consul-lambda/pull/78)
+
 ## 0.1.0-beta4 (Apr 28, 2023)
 
-IMPROVEMENTS:
+IMPROVEMENTS
 * Pin the version of the `terraform-aws-modules/eventbridge/aws` module to v1.17.3. This ensures the selection of the eventbridge module is deterministic when using the `lambda-registrator` Terraform module.
   [[GH-70]](https://github.com/hashicorp/terraform-aws-consul-lambda/pull/70)
 
-BUG FIXES:
+BUG FIXES
 * Disable Cgo compilation for Lambda registrator and extension. Compiling without `CGO_ENABLED=0` on Go 1.20 [causes an issue](https://github.com/hashicorp/terraform-aws-consul-lambda/issues/57) that does not allow Lambda registrator or the Lambda extension to execute within the AWS Lambda runtime.
   [[GH-68]](https://github.com/hashicorp/terraform-aws-consul-lambda/pull/68)
 
@@ -19,7 +25,7 @@ BREAKING CHANGES
 FEATURES
 * Update minimum go version for project to 1.20 [[GH-1908]](https://github.com/hashicorp/terraform-aws-consul-lambda/pull/54)
 
-BUG FIXES:
+BUG FIXES
 * Security:
     * Upgrade to use Go 1.20.1 This resolves vulnerabilities [CVE-2022-41724](https://go.dev/issue/58001) in `crypto/tls` and [CVE-2022-41723](https://go.dev/issue/57855) in `net/http`. [[GH-1908]](https://github.com/hashicorp/terraform-aws-consul-lambda/pull/54)
 

--- a/consul-lambda/client/ssm.go
+++ b/consul-lambda/client/ssm.go
@@ -15,11 +15,18 @@ import (
 // SSMClient provides an API client for interacting with AWS Systems Manager Parameter Store.
 type SSMClient struct {
 	client *ssm.Client
+	tier   types.ParameterTier
 }
 
 // NewSSM creates an instance of the SSMClient from the given AWS SDK config.
-func NewSSM(cfg *aws.Config) *SSMClient {
-	return &SSMClient{client: ssm.NewFromConfig(*cfg)}
+func NewSSM(cfg *aws.Config, aTier bool) *SSMClient {
+	var tier = types.ParameterTierStandard
+
+	if aTier {
+		tier = types.ParameterTierAdvanced
+	}
+
+	return &SSMClient{client: ssm.NewFromConfig(*cfg), tier: tier}
 }
 
 // Delete removes the value for the given key from Parameter Store.
@@ -52,22 +59,15 @@ func (c *SSMClient) Get(ctx context.Context, key string) (string, error) {
 // Set writes the value for the given key to Parameter Store.
 // It writes the value as an encrypted SecureString.
 // Any existing data for the given key is overwritten.
-func (c *SSMClient) Set(ctx context.Context, key, val string, advancedTier bool) error {
-	tierType := types.ParameterTierStandard
-
-	if advancedTier {
-		tierType = types.ParameterTierAdvanced
+func (c *SSMClient) Set(ctx context.Context, key, val string) error {
+	input := &ssm.PutParameterInput{
+		Name:      &key,
+		Value:     &val,
+		Overwrite: true,
+		Type:      types.ParameterTypeSecureString,
+		Tier: c.tier
 	}
 
-	_, err := c.client.PutParameter(
-		ctx,
-		&ssm.PutParameterInput{
-			Name:      &key,
-			Value:     &val,
-			Overwrite: true,
-			Type:      types.ParameterTypeSecureString,
-			Tier:      tierType,
-		},
-	)
+	_, err := c.client.PutParameter(ctx,input)
 	return err
 }

--- a/consul-lambda/client/ssm.go
+++ b/consul-lambda/client/ssm.go
@@ -60,14 +60,20 @@ func (c *SSMClient) Get(ctx context.Context, key string) (string, error) {
 // It writes the value as an encrypted SecureString.
 // Any existing data for the given key is overwritten.
 func (c *SSMClient) Set(ctx context.Context, key, val string) error {
+	if c.tier == types.ParameterTierAdvanced {
+		if len(val) < 4097 {
+			c.tier = types.ParameterTierStandard
+		}
+	}
+
 	input := &ssm.PutParameterInput{
 		Name:      &key,
 		Value:     &val,
 		Overwrite: true,
 		Type:      types.ParameterTypeSecureString,
-		Tier: c.tier
+		Tier:      c.tier,
 	}
 
-	_, err := c.client.PutParameter(ctx,input)
+	_, err := c.client.PutParameter(ctx, input)
 	return err
 }

--- a/consul-lambda/client/ssm.go
+++ b/consul-lambda/client/ssm.go
@@ -52,7 +52,13 @@ func (c *SSMClient) Get(ctx context.Context, key string) (string, error) {
 // Set writes the value for the given key to Parameter Store.
 // It writes the value as an encrypted SecureString.
 // Any existing data for the given key is overwritten.
-func (c *SSMClient) Set(ctx context.Context, key, val string) error {
+func (c *SSMClient) Set(ctx context.Context, key, val string, advancedTier bool) error {
+	tierType := types.ParameterTierStandard
+
+	if advancedTier {
+		tierType = types.ParameterTierAdvanced
+	}
+
 	_, err := c.client.PutParameter(
 		ctx,
 		&ssm.PutParameterInput{
@@ -60,6 +66,7 @@ func (c *SSMClient) Set(ctx context.Context, key, val string) error {
 			Value:     &val,
 			Overwrite: true,
 			Type:      types.ParameterTypeSecureString,
+			Tier:      tierType,
 		},
 	)
 	return err

--- a/consul-lambda/consul-lambda-extension/main.go
+++ b/consul-lambda/consul-lambda-extension/main.go
@@ -103,7 +103,7 @@ func configure() (*Config, error) {
 		return cfg, fmt.Errorf("failed to create AWS SDK configuration: %w", err)
 	}
 
-	ssmClient := client.NewSSM(&sdkConfig)
+	ssmClient := client.NewSSM(&sdkConfig, "")
 
 	lambdaClient := NewLambda()
 	err = lambdaClient.Register(context.Background(), extensionName)

--- a/consul-lambda/consul-lambda-registrator/environment.go
+++ b/consul-lambda/consul-lambda-registrator/environment.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -119,7 +120,12 @@ func SetupEnvironment(ctx context.Context) (Environment, error) {
 		return env, err
 	}
 
-	env.Store = client.NewSSM(&sdkConfig)
+	advancedTier, err := strconv.ParseBool(os.Getenv("CONSUL_ADVANCED_PARAMS"))
+	if err != nil {
+		env.Logger.Debug("Unable to parse (true, false) setting to standard tier parameter")
+	}
+
+	env.Store = client.NewSSM(&sdkConfig, advancedTier)
 	env.Lambda = NewLambdaClient(&sdkConfig, env.PageSize)
 
 	err = setConsulHTTPToken(ctx, env.Store, env.ConsulHTTPTokenPath)

--- a/consul-lambda/consul-lambda-registrator/environment.go
+++ b/consul-lambda/consul-lambda-registrator/environment.go
@@ -124,7 +124,7 @@ func SetupEnvironment(ctx context.Context) (Environment, error) {
 		return env, err
 	}
 
-	env.Store = client.NewSSM(&sdkConfig, env.ExtenstionDataTier)
+	env.Store = client.NewSSM(&sdkConfig, env.ExtensionDataTier)
 	env.Lambda = NewLambdaClient(&sdkConfig, env.PageSize)
 
 	err = setConsulHTTPToken(ctx, env.Store, env.ConsulHTTPTokenPath)

--- a/consul-lambda/consul-lambda-registrator/upsert_event.go
+++ b/consul-lambda/consul-lambda-registrator/upsert_event.go
@@ -178,7 +178,6 @@ func (env Environment) upsertTLSData(e UpsertEvent) error {
 	advancedTier, err = strconv.ParseBool(os.Getenv("CONSUL_ADVANCED_PARAMS"))
 	if err != nil {
 		env.Logger.Debug("Unable to parse (true, false) setting to standard tier parameter")
-		advancedTier = false
 	}
 	// TODO: do we need to pass a context in here?.. like from the lambda entrypoint
 	// so that this call can be canceled if necessary.

--- a/consul-lambda/consul-lambda-registrator/upsert_event.go
+++ b/consul-lambda/consul-lambda-registrator/upsert_event.go
@@ -178,7 +178,7 @@ func (env Environment) upsertTLSData(e UpsertEvent) error {
 	advancedTier, err = strconv.ParseBool(os.Getenv("CONSUL_ADVANCED_PARAMS"))
 	if err != nil {
 		env.Logger.Debug("Unable to parse (true, false) setting to standard tier parameter")
-		advancedTier = true
+		advancedTier = false
 	}
 	// TODO: do we need to pass a context in here?.. like from the lambda entrypoint
 	// so that this call can be canceled if necessary.

--- a/consul-lambda/consul-lambda-registrator/upsert_event.go
+++ b/consul-lambda/consul-lambda-registrator/upsert_event.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
-	"strconv"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/terraform-aws-consul-lambda/consul-lambda/structs"
@@ -175,13 +173,9 @@ func (env Environment) upsertTLSData(e UpsertEvent) error {
 	}
 	path := fmt.Sprintf("%s%s", env.ExtensionDataPrefix, service.ExtensionPath())
 
-	advancedTier, err = strconv.ParseBool(os.Getenv("CONSUL_ADVANCED_PARAMS"))
-	if err != nil {
-		env.Logger.Debug("Unable to parse (true, false) setting to standard tier parameter")
-	}
 	// TODO: do we need to pass a context in here?.. like from the lambda entrypoint
 	// so that this call can be canceled if necessary.
-	return env.Store.Set(context.Background(), path, string(extData), advancedTier)
+	return env.Store.Set(context.Background(), path, string(extData))
 }
 
 // QueryOptions takes in a structs.Service and returns a pointer to an api.QueryOptions struct.

--- a/consul-lambda/consul-lambda-registrator/upsert_event.go
+++ b/consul-lambda/consul-lambda-registrator/upsert_event.go
@@ -180,7 +180,6 @@ func (env Environment) upsertTLSData(e UpsertEvent) error {
 		env.Logger.Debug("Unable to parse (true, false) setting to standard tier parameter")
 		advancedTier = true
 	}
-
 	// TODO: do we need to pass a context in here?.. like from the lambda entrypoint
 	// so that this call can be canceled if necessary.
 	return env.Store.Set(context.Background(), path, string(extData), advancedTier)

--- a/consul-lambda/consul-lambda-registrator/upsert_event.go
+++ b/consul-lambda/consul-lambda-registrator/upsert_event.go
@@ -118,7 +118,6 @@ func (env Environment) storeServiceDefaults(e UpsertEvent) error {
 }
 
 func (env Environment) upsertTLSData(e UpsertEvent) error {
-	var advancedTier bool
 	if !env.IsManagingTLS() {
 		return nil
 	}

--- a/consul-lambda/consul-lambda-registrator/upsert_event.go
+++ b/consul-lambda/consul-lambda-registrator/upsert_event.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"strconv"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/terraform-aws-consul-lambda/consul-lambda/structs"
@@ -118,6 +120,7 @@ func (env Environment) storeServiceDefaults(e UpsertEvent) error {
 }
 
 func (env Environment) upsertTLSData(e UpsertEvent) error {
+	var advancedTier bool
 	if !env.IsManagingTLS() {
 		return nil
 	}
@@ -172,9 +175,15 @@ func (env Environment) upsertTLSData(e UpsertEvent) error {
 	}
 	path := fmt.Sprintf("%s%s", env.ExtensionDataPrefix, service.ExtensionPath())
 
+	advancedTier, err = strconv.ParseBool(os.Getenv("CONSUL_ADVANCED_PARAMS"))
+	if err != nil {
+		env.Logger.Debug("Unable to parse (true, false) setting to standard tier parameter")
+		advancedTier = true
+	}
+
 	// TODO: do we need to pass a context in here?.. like from the lambda entrypoint
 	// so that this call can be canceled if necessary.
-	return env.Store.Set(context.Background(), path, string(extData))
+	return env.Store.Set(context.Background(), path, string(extData), advancedTier)
 }
 
 // QueryOptions takes in a structs.Service and returns a pointer to an api.QueryOptions struct.

--- a/modules/lambda-registrator/main.tf
+++ b/modules/lambda-registrator/main.tf
@@ -155,6 +155,9 @@ resource "aws_lambda_function" "registration" {
       } : {},
       var.consul_extension_data_prefix != "" ? {
         CONSUL_EXTENSION_DATA_PREFIX = var.consul_extension_data_prefix
+      } : {},
+      var.consul_extension_data_tier != "" ? {
+        CONSUL_EXTENSION_DATA_TIER = var.consul_extension_data_tier
       } : {}
     )
   }

--- a/modules/lambda-registrator/variables.tf
+++ b/modules/lambda-registrator/variables.tf
@@ -99,3 +99,13 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "consul_extension_data_tier" {
+  description = <<-EOT
+  The tier to use for storing data in Parameter Store.
+  Refer to the Parameter Store documentation for applicable values (https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-advanced-parameters.html).
+  If this is unset the default tier will be used.
+  EOT
+  type        = string
+  default     = ""
+}

--- a/modules/lambda-registrator/variables.tf
+++ b/modules/lambda-registrator/variables.tf
@@ -35,6 +35,16 @@ variable "consul_extension_data_prefix" {
   default     = ""
 }
 
+variable "consul_extension_data_tier" {
+  description = <<-EOT
+  The tier to use for storing data in Parameter Store.
+  Refer to the Parameter Store documentation for applicable values (https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-advanced-parameters.html).
+  If this is unset the default tier will be used.
+  EOT
+  type        = string
+  default     = ""
+}
+
 variable "node_name" {
   description = "The Consul node that Lambdas will be registered to."
   type        = string
@@ -98,14 +108,4 @@ variable "tags" {
   description = "Additional tags to set on the Lambda registrator."
   type        = map(string)
   default     = {}
-}
-
-variable "consul_extension_data_tier" {
-  description = <<-EOT
-  The tier to use for storing data in Parameter Store.
-  Refer to the Parameter Store documentation for applicable values (https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-advanced-parameters.html).
-  If this is unset the default tier will be used.
-  EOT
-  type        = string
-  default     = ""
 }

--- a/test/acceptance/setup-terraform/main.tf
+++ b/test/acceptance/setup-terraform/main.tf
@@ -11,6 +11,10 @@ terraform {
 }
 
 provider "aws" {
+  region = var.region
+}
+
+provider "aws" {
   alias  = "provider"
   region = var.region
 }

--- a/test/acceptance/tests/lambda-to-mesh/main.tf
+++ b/test/acceptance/tests/lambda-to-mesh/main.tf
@@ -11,6 +11,10 @@ terraform {
 }
 
 provider "aws" {
+  region = var.region
+}
+
+provider "aws" {
   alias  = "provider"
   region = var.region
 }

--- a/test/acceptance/tests/mesh-to-lambda/main.tf
+++ b/test/acceptance/tests/mesh-to-lambda/main.tf
@@ -11,6 +11,10 @@ terraform {
 }
 
 provider "aws" {
+  region = var.region
+}
+
+provider "aws" {
   alias  = "provider"
   region = var.region
 }

--- a/test/acceptance/tests/setup/main.tf
+++ b/test/acceptance/tests/setup/main.tf
@@ -14,6 +14,11 @@ provider "aws" {
   region = var.region
 }
 
+provider "aws" {
+  alias  = "provider"
+  region = var.region
+}
+
 data "aws_caller_identity" "current" {}
 
 data "aws_availability_zones" "available" {

--- a/test/acceptance/tests/setup/variables.tf
+++ b/test/acceptance/tests/setup/variables.tf
@@ -11,7 +11,7 @@ variable "setup_suffix" {
 
 variable "region" {
   type    = string
-  default = "us-east-1"
+  default = "us-west-2"
 }
 
 variable "secure" {


### PR DESCRIPTION
## Changes proposed in this PR:

In this PR per issue #77 currently if the configuration the registrator stores is larger than 4096 bytes, the registrator will continue to run, however data will fail to be stored in SSM, causing the related lambda to be unable to communicate *into* the mesh.

This PR adds an environment variable `CONSUL_ADVANCED_PARAMS` that, if set to true, will allow the storage of advanced parameters.

A Future enhancement could be made to check the size of the value being stored, and if >4096 then set it to true.


## How I've tested this PR:

I have built the binary and uploaded it to my aws account successfully.

## How I expect reviewers to test this PR:

Build the registrator binary, and upload it per the terraform module instructions.

## Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
