### PR TITLE
Add support for pushing `consul-lambda-registrator` public image to p…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ FEATURES
 * Add support for storing parameter values greater than 4 KB. The `lambda-registrator` module and source code have been updated to accept a configurable value for the [SSM parameter tier](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-advanced-parameters.html). This allows users to choose if they want to use the `Advanced` tier feature. Charges apply for the `Advanved` tier so if the tier is not expressly set to `Advanced`, then the `Standard` tier will be used. Using the `Advanced` tier allows for parameter values up to 8 KB. The Lambda-registrator Terraform module can be configured using the new `consul_extension_data_tier` variable.
   [[GH-78]](https://github.com/hashicorp/terraform-aws-consul-lambda/pull/78)
 
+* Add support for pushing `consul-lambda-registrator` public image to private ecr repo through terraform.
+  [[GH-82]](https://github.com/hashicorp/terraform-aws-consul-lambda/pull/82)
+
 ## 0.1.0-beta4 (Apr 28, 2023)
 
 IMPROVEMENTS

--- a/examples/lambda/README.md
+++ b/examples/lambda/README.md
@@ -110,7 +110,7 @@ This example Terraform workspace will use the zip package to deploy the `consul-
 add it to the `lambda-app-2` function so that it can call services within the Consul service mesh.
 
 ```shell
-curl -o consul-lambda-extension.zip https://releases.hashicorp.com/consul-lambda-extension/${VERSION}/consul-lambda-extension_${VERSION}_linux_amd64.zip
+curl -o consul-lambda-extension.zip "https://releases.hashicorp.com/consul-lambda-extension/${VERSION}/consul-lambda-extension_${VERSION}_linux_amd64.zip"
 ```
 
 ## Build the example Lambda function

--- a/examples/lambda/lambda/variables.tf
+++ b/examples/lambda/lambda/variables.tf
@@ -94,7 +94,7 @@ variable "invocation_mode" {
   default     = "SYNCHRONOUS"
   validation {
     condition     = contains(["SYNCHRONOUS", "ASYNCHRONOUS"], var.invocation_mode)
-    error_message = "invocation_mode must be one of SYNCHRONOUS or ASYNCHRONOUS"
+    error_message = "Variable invocation_mode must be one of SYNCHRONOUS or ASYNCHRONOUS."
   }
 }
 

--- a/examples/lambda/providers.tf
+++ b/examples/lambda/providers.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.25.0"
+      version = "5.17.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/lambda/providers.tf
+++ b/examples/lambda/providers.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.17.0"
+      version = "4.67.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/lambda/variables.tf
+++ b/examples/lambda/variables.tf
@@ -38,3 +38,14 @@ variable "consul_lambda_extension_arn" {
   type        = string
   default     = ""
 }
+
+variable "consul_lambda_registrator_image" {
+  description = "The Lambda registrator image to use. Must be provided as <registry/repository:tag>"
+  type        = string
+  default     = "public.ecr.aws/hashicorp/consul-lambda-registrator:0.1.0-beta4"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.-]+/[a-z0-9_.-]+/[a-z0-9_.-]+:[a-zA-Z0-9_.-]+$", var.consul_lambda_registrator_image))
+    error_message = "Image format of 'consul_lambda_registrator_image' is invalid. It should be in the format 'registry/repository:tag'."
+  }
+}

--- a/modules/lambda-registrator/main.tf
+++ b/modules/lambda-registrator/main.tf
@@ -28,7 +28,8 @@ locals {
 
 # Equivalent of aws ecr get-login
 data "aws_ecr_authorization_token" "ecr_auth" {}
-
+data "aws_region" "current_region" {}
+data "aws_caller_identity" "current_identity" {}
 
 provider "docker" {
   host = var.docker_host
@@ -38,8 +39,7 @@ provider "docker" {
     address  = "${data.aws_caller_identity.current_identity.account_id}.dkr.ecr.${data.aws_region.current_region.name}.amazonaws.com"
   }
 }
-data "aws_region" "current_region" {}
-data "aws_caller_identity" "current_identity" {}
+
 resource "aws_iam_role" "registration" {
   name = var.name
 

--- a/modules/lambda-registrator/main.tf
+++ b/modules/lambda-registrator/main.tf
@@ -160,29 +160,29 @@ resource "random_id" "repo_id" {
 }
 
 resource "aws_ecr_repository" "lambda-registrator" {
-  count        = var.ecr_image_uri != "" ? 0 : 1
+  count        = var.enable_auto_publish_ecr_image ? 1 : 0
   name         = local.ecr_repo_name
   force_delete = true
 }
 
 resource "docker_image" "lambda_registrator" {
-  count = var.ecr_image_uri != "" ? 0 : 1
+  count = var.enable_auto_publish_ecr_image ? 1 : 0
   name  = var.consul_lambda_registrator_image
 }
 
 resource "docker_tag" "lambda_registrator_tag" {
-  count        = var.ecr_image_uri != "" ? 0 : 1
+  count        = var.enable_auto_publish_ecr_image ? 1 : 0
   source_image = docker_image.lambda_registrator[count.index].name
   target_image = local.generated_ecr_image_uri
 }
 resource "docker_registry_image" "push_image" {
-  count         = var.ecr_image_uri != "" ? 0 : 1
+  count         = var.enable_auto_publish_ecr_image ? 1 : 0
   name          = docker_tag.lambda_registrator_tag[count.index].target_image
   keep_remotely = true
 }
 
 resource "aws_lambda_function" "registration" {
-  image_uri                      = var.ecr_image_uri != "" ? var.ecr_image_uri : local.generated_ecr_image_uri
+  image_uri                      = var.enable_auto_publish_ecr_image ? local.generated_ecr_image_uri : var.ecr_image_uri
   package_type                   = "Image"
   function_name                  = var.name
   role                           = aws_iam_role.registration.arn

--- a/modules/lambda-registrator/main.tf
+++ b/modules/lambda-registrator/main.tf
@@ -10,6 +10,7 @@ terraform {
 
   }
 }
+
 locals {
   on_vpc = length(var.subnet_ids) > 0 && length(var.security_group_ids) > 0
   vpc_config = local.on_vpc ? [{

--- a/modules/lambda-registrator/main.tf
+++ b/modules/lambda-registrator/main.tf
@@ -156,7 +156,7 @@ resource "aws_iam_role_policy_attachment" "lambda_logs" {
   policy_arn = aws_iam_policy.policy.arn
 }
 resource "random_id" "repo_id" {
-  byte_length = 8
+  byte_length = 4
 }
 
 resource "aws_ecr_repository" "lambda-registrator" {

--- a/modules/lambda-registrator/main.tf
+++ b/modules/lambda-registrator/main.tf
@@ -18,9 +18,9 @@ locals {
   }] : []
   cron_key          = "${var.name}-cron"
   lambda_events_key = "${var.name}-lambda_events"
-  image_parts                = split(":", var.consul_lambda_registrator_image)
-  image_tag                  = local.image_parts[1]
-  ecr_image_uri = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${var.region}.amazonaws.com/${var.private_ecr_repo_name}:${local.image_tag}"
+  image_parts       = split(":", var.consul_lambda_registrator_image)
+  image_tag         = local.image_parts[1]
+  ecr_image_uri     = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${var.region}.amazonaws.com/${var.private_ecr_repo_name}:${local.image_tag}"
 }
 
 # Equivalent of aws ecr get-login
@@ -161,8 +161,8 @@ resource "aws_ecr_repository" "lambda-registrator" {
 
 
 resource "docker_image" "lambda_registrator" {
-  count        = var.ecr_image_uri != "" ? 0 : 1
-  name         = var.consul_lambda_registrator_image
+  count = var.ecr_image_uri != "" ? 0 : 1
+  name  = var.consul_lambda_registrator_image
 }
 
 resource "docker_tag" "lambda_registrator_tag" {
@@ -171,7 +171,7 @@ resource "docker_tag" "lambda_registrator_tag" {
   target_image = local.ecr_image_uri
 }
 resource "docker_registry_image" "push_image" {
-  count = var.ecr_image_uri != "" ? 0 : 1
+  count         = var.ecr_image_uri != "" ? 0 : 1
   name          = docker_tag.lambda_registrator_tag[count.index].target_image
   keep_remotely = true
 }

--- a/modules/lambda-registrator/main.tf
+++ b/modules/lambda-registrator/main.tf
@@ -175,6 +175,7 @@ resource "docker_tag" "lambda_registrator_tag" {
   source_image = docker_image.lambda_registrator[count.index].name
   target_image = local.generated_ecr_image_uri
 }
+
 resource "docker_registry_image" "push_image" {
   count         = var.enable_auto_publish_ecr_image ? 1 : 0
   name          = docker_tag.lambda_registrator_tag[count.index].target_image

--- a/modules/lambda-registrator/main.tf
+++ b/modules/lambda-registrator/main.tf
@@ -158,12 +158,12 @@ resource "aws_iam_role_policy_attachment" "lambda_logs" {
 resource "random_id" "repo_id" {
   byte_length = 8
 }
+
 resource "aws_ecr_repository" "lambda-registrator" {
   count        = var.ecr_image_uri != "" ? 0 : 1
   name         = local.ecr_repo_name
   force_delete = true
 }
-
 
 resource "docker_image" "lambda_registrator" {
   count = var.ecr_image_uri != "" ? 0 : 1

--- a/modules/lambda-registrator/validations.tf
+++ b/modules/lambda-registrator/validations.tf
@@ -1,0 +1,3 @@
+locals {
+  require_ecr_image_uri_or_enable_auto_publish_ecr_image_set = var.ecr_image_uri == "" && var.enable_auto_publish_ecr_image == false ? file("ERROR: either ecr_image_uri or enable_auto_publish_ecr_image must be set") : null
+}

--- a/modules/lambda-registrator/variables.tf
+++ b/modules/lambda-registrator/variables.tf
@@ -123,7 +123,7 @@ variable "consul_lambda_registrator_image" {
 
   validation {
     condition     = can(regex("^[a-zA-Z0-9_.-]+/[a-z0-9_.-]+/[a-z0-9_.-]+:[a-zA-Z0-9_.-]+$", var.consul_lambda_registrator_image))
-    error_message = "Image format of 'consul_lambda_registrator_image' is invalid. It should be in the format 'registry/repository:tag'."
+    error_message = "Image format of 'consul_lambda_registrator_image' is invalid. It must be in the format 'registry/repository:tag'."
   }
 }
 

--- a/modules/lambda-registrator/variables.tf
+++ b/modules/lambda-registrator/variables.tf
@@ -135,7 +135,14 @@ variable "docker_host" {
 }
 
 variable "enable_auto_publish_ecr_image" {
-  description = "enables auto pushing public image to private ecr repo if set to true"
+  description = <<EOF
+    Enables auto pushing public image to private ecr repo if set to true
+    NOTE:-
+    Atleast one of ecr_image_uri or enable_auto_publish_ecr_image should be set.
+    When enable_auto_publish_ecr_image is set, the image defined by consul_lambda_registrator_image will be pulled and published to private_ecr_repo_name.
+    That this method requires local access to docker.
+
+    EOF
   type        = bool
   default     = false
 }

--- a/modules/lambda-registrator/variables.tf
+++ b/modules/lambda-registrator/variables.tf
@@ -109,3 +109,32 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "region" {
+  type        = string
+  description = "AWS region to deploy Lambda registrator."
+  default     = "us-east-1"
+}
+
+variable "private_ecr_repo_name" {
+  description = "The name of the repository to republish the ECR image if one exists. If no name is passed, it is assumed that no repository exists and one needs to be created."
+  type        = string
+  default     = "consul-lambda-registrator"
+}
+
+variable "consul_lambda_registrator_image" {
+  description = "The Lambda registrator image to use. Must be provided as <registry/repository:tag>"
+  type        = string
+  default     = "public.ecr.aws/hashicorp/consul-lambda-registrator:0.1.0-beta4"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.-]+/[a-z0-9_.-]+/[a-z0-9_.-]+:[a-zA-Z0-9_.-]+$", var.consul_lambda_registrator_image))
+    error_message = "Image format of 'consul_lambda_registrator_image' is invalid. It should be in the format 'registry/repository:tag'."
+  }
+}
+
+variable "docker_host" {
+  description = "The docker socket for your system"
+  type        = string
+  default     = "unix:///var/run/docker.sock"
+}

--- a/modules/lambda-registrator/variables.tf
+++ b/modules/lambda-registrator/variables.tf
@@ -110,16 +110,10 @@ variable "tags" {
   default     = {}
 }
 
-variable "region" {
-  type        = string
-  description = "AWS region to deploy Lambda registrator."
-  default     = "us-east-1"
-}
-
 variable "private_ecr_repo_name" {
   description = "The name of the repository to republish the ECR image if one exists. If no name is passed, it is assumed that no repository exists and one needs to be created."
   type        = string
-  default     = "consul-lambda-registrator"
+  default     = ""
 }
 
 variable "consul_lambda_registrator_image" {

--- a/modules/lambda-registrator/variables.tf
+++ b/modules/lambda-registrator/variables.tf
@@ -135,14 +135,14 @@ variable "docker_host" {
 }
 
 variable "enable_auto_publish_ecr_image" {
-  description = <<EOF
-    Enables auto pushing public image to private ecr repo if set to true
-    NOTE:-
-    Atleast one of ecr_image_uri or enable_auto_publish_ecr_image should be set.
-    When enable_auto_publish_ecr_image is set, the image defined by consul_lambda_registrator_image will be pulled and published to private_ecr_repo_name.
-    That this method requires local access to docker.
-
-    EOF
+  description = <<-EOT
+    Enables automatic publishing of a public Lambda Registrator image to a private ECR repository via Docker.
+    When enable_auto_publish_ecr_image is set to true, the image defined by consul_lambda_registrator_image will be pulled and published to a private ECR repository. If private_ecr_repo_name is set, that name will be used to create the private ECR repository, otherwise the default name, consul-lambda-registrator-<random-suffix>, will be used
+    
+    You must set at least one of ecr_image_uri or enable_auto_publish_ecr_image. If enable_auto_publish_ecr_image is set to true then ecr_image_uri is ignored.
+    
+    Using this method to automatically pull the public image and push it to a private ECR repository requires access to the docker command in the local environment.
+    EOT
   type        = bool
   default     = false
 }

--- a/modules/lambda-registrator/variables.tf
+++ b/modules/lambda-registrator/variables.tf
@@ -84,6 +84,7 @@ variable "ecr_image_uri" {
   repository or configuring pull through cache rules (https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache.html).
   EOT
   type        = string
+  default     = ""
 }
 
 variable "sync_frequency_in_minutes" {
@@ -131,4 +132,10 @@ variable "docker_host" {
   description = "The docker socket for your system"
   type        = string
   default     = "unix:///var/run/docker.sock"
+}
+
+variable "enable_auto_publish_ecr_image" {
+  description = "enables auto pushing public image to private ecr repo if set to true"
+  type        = bool
+  default     = false
 }

--- a/test/acceptance/setup-terraform/ecr.tf
+++ b/test/acceptance/setup-terraform/ecr.tf
@@ -8,7 +8,6 @@ locals {
 }
 
 resource "aws_ecr_repository" "lambda-registrator" {
-  count        = var.enable_auto_publish_ecr_image ? 1 : 0
   name         = local.ecr_repository_name
   force_delete = true
 }

--- a/test/acceptance/setup-terraform/ecr.tf
+++ b/test/acceptance/setup-terraform/ecr.tf
@@ -8,7 +8,7 @@ locals {
 }
 
 resource "aws_ecr_repository" "lambda-registrator" {
-  name = local.ecr_repository_name
+  name         = local.ecr_repository_name
   force_delete = true
 }
 

--- a/test/acceptance/setup-terraform/ecr.tf
+++ b/test/acceptance/setup-terraform/ecr.tf
@@ -8,6 +8,7 @@ locals {
 }
 
 resource "aws_ecr_repository" "lambda-registrator" {
+  count        = var.enable_auto_publish_ecr_image ? 1 : 0
   name         = local.ecr_repository_name
   force_delete = true
 }

--- a/test/acceptance/setup-terraform/ecr.tf
+++ b/test/acceptance/setup-terraform/ecr.tf
@@ -9,6 +9,7 @@ locals {
 
 resource "aws_ecr_repository" "lambda-registrator" {
   name = local.ecr_repository_name
+  force_delete = true
 }
 
 resource "null_resource" "push-lambda-registrator-to-ecr" {

--- a/test/acceptance/setup-terraform/main.tf
+++ b/test/acceptance/setup-terraform/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.17.0"
+      version = "4.67.0"
     }
   }
 }

--- a/test/acceptance/setup-terraform/main.tf
+++ b/test/acceptance/setup-terraform/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.14.0"
+      version = "5.17.0"
     }
   }
 }

--- a/test/acceptance/setup-terraform/variables.tf
+++ b/test/acceptance/setup-terraform/variables.tf
@@ -5,3 +5,9 @@ variable "region" {
   default     = "us-west-2"
   description = "AWS region"
 }
+
+variable "enable_auto_publish_ecr_image" {
+  description = "enables auto pushing public image to private ecr repo if set to true"
+  type        = bool
+  default     = false
+}

--- a/test/acceptance/setup-terraform/variables.tf
+++ b/test/acceptance/setup-terraform/variables.tf
@@ -5,9 +5,3 @@ variable "region" {
   default     = "us-west-2"
   description = "AWS region"
 }
-
-variable "enable_auto_publish_ecr_image" {
-  description = "enables auto pushing public image to private ecr repo if set to true"
-  type        = bool
-  default     = false
-}

--- a/test/acceptance/tests/basic_test.go
+++ b/test/acceptance/tests/basic_test.go
@@ -67,7 +67,7 @@ func TestBasic(t *testing.T) {
 			namespace := ""
 			partition := ""
 			queryString := ""
-			tfVars["consul_image"] = "public.ecr.aws/hashicorp/consul:1.15.1"
+			tfVars["consul_image"] = "public.ecr.aws/hashicorp/consul:1.16.1"
 			if c.enterprise {
 				tfVars["consul_license"] = os.Getenv("CONSUL_LICENSE")
 				require.NotEmpty(t, tfVars["consul_license"], "CONSUL_LICENSE environment variable is required for enterprise tests")

--- a/test/acceptance/tests/basic_test.go
+++ b/test/acceptance/tests/basic_test.go
@@ -31,8 +31,9 @@ type SetupConfig struct {
 
 func TestBasic(t *testing.T) {
 	cases := map[string]struct {
-		secure     bool
-		enterprise bool
+		secure                 bool
+		enterprise             bool
+		autoPublishRegistrator bool
 	}{
 		"secure": {
 			secure: true,
@@ -43,6 +44,10 @@ func TestBasic(t *testing.T) {
 		"enterprise and secure": {
 			secure:     true,
 			enterprise: true,
+		},
+		"secure auto publish": {
+			secure:                 true,
+			autoPublishRegistrator: true,
 		},
 	}
 
@@ -55,7 +60,9 @@ func TestBasic(t *testing.T) {
 			partition := ""
 			queryString := ""
 			tfVars["consul_image"] = "public.ecr.aws/hashicorp/consul:1.15.1"
-
+			if c.autoPublishRegistrator {
+				tfVars["ecr_image_uri"] = ""
+			}
 			if c.enterprise {
 				tfVars["consul_license"] = os.Getenv("CONSUL_LICENSE")
 				require.NotEmpty(t, tfVars["consul_license"], "CONSUL_LICENSE environment variable is required for enterprise tests")

--- a/test/acceptance/tests/basic_test.go
+++ b/test/acceptance/tests/basic_test.go
@@ -34,6 +34,7 @@ func TestBasic(t *testing.T) {
 		secure                 bool
 		enterprise             bool
 		autoPublishRegistrator bool
+		privateEcrRepoName     string
 	}{
 		"secure": {
 			secure: true,
@@ -48,6 +49,11 @@ func TestBasic(t *testing.T) {
 		"secure auto publish": {
 			secure:                 true,
 			autoPublishRegistrator: true,
+		},
+		"secure auto publish with privateEcrRepoName": {
+			secure:                 true,
+			autoPublishRegistrator: true,
+			privateEcrRepoName:     "test-ecr-repo",
 		},
 	}
 
@@ -80,6 +86,9 @@ func TestBasic(t *testing.T) {
 
 			if c.autoPublishRegistrator {
 				tfVars["enable_auto_publish_ecr_image"] = true
+				if c.privateEcrRepoName != "" {
+					tfVars["private_ecr_repo_name"] = c.privateEcrRepoName
+				}
 			}
 
 			setupTerraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{

--- a/test/acceptance/tests/basic_test.go
+++ b/test/acceptance/tests/basic_test.go
@@ -74,7 +74,7 @@ func TestBasic(t *testing.T) {
 				tfVars["consul_namespace"] = namespace
 				tfVars["consul_partition"] = partition
 				queryString = fmt.Sprintf("?partition=%s&ns=%s", partition, namespace)
-				tfVars["consul_image"] = "public.ecr.aws/hashicorp/consul-enterprise:1.15.1-ent"
+				tfVars["consul_image"] = "public.ecr.aws/hashicorp/consul-enterprise:1.16.1-ent"
 			}
 
 			setupSuffix := tfVars["suffix"]

--- a/test/acceptance/tests/basic_test.go
+++ b/test/acceptance/tests/basic_test.go
@@ -92,6 +92,7 @@ func TestBasic(t *testing.T) {
 					Vars:         tfVars,
 					NoColor:      true,
 				})
+				terraform.Init(t, setupTerraformOptions)
 				_, err := terraform.PlanE(t, setupTerraformOptions)
 				require.Error(t, err)
 				// error messages are wrapped, so a space may turn into a newline.

--- a/test/acceptance/tests/lambda-to-mesh/main.tf
+++ b/test/acceptance/tests/lambda-to-mesh/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.14.0"
+      version = "4.67.0"
     }
   }
 }

--- a/test/acceptance/tests/lambda/main.tf
+++ b/test/acceptance/tests/lambda/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.14.0"
+      version = "4.67.0"
 
       configuration_aliases = [aws.provider]
     }

--- a/test/acceptance/tests/mesh-to-lambda/main.tf
+++ b/test/acceptance/tests/mesh-to-lambda/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.14.0"
+      version = "4.67.0"
     }
   }
 }

--- a/test/acceptance/tests/setup/main.tf
+++ b/test/acceptance/tests/setup/main.tf
@@ -62,16 +62,16 @@ resource "aws_ssm_parameter" "ca_cert" {
 module "lambda-registration" {
   source = "../../../../modules/lambda-registrator"
 
-  name                      = "lambda-registrator-1-${var.suffix}"
-  consul_http_addr          = local.consul_http_addr
-  consul_ca_cert_path       = aws_ssm_parameter.ca_cert.name
-  consul_http_token_path    = var.secure ? aws_ssm_parameter.acl_token[0].name : ""
-  ecr_image_uri             = var.ecr_image_uri
-  subnet_ids                = var.private_subnets
-  security_group_ids        = [data.aws_security_group.vpc_default.id]
-  sync_frequency_in_minutes = 1
-  partitions                = local.enterprise ? ["default", var.consul_partition] : []
-  enterprise                = local.enterprise
-
-  consul_extension_data_prefix = "/${var.suffix}"
+  name                          = "lambda-registrator-1-${var.suffix}"
+  consul_http_addr              = local.consul_http_addr
+  consul_ca_cert_path           = aws_ssm_parameter.ca_cert.name
+  consul_http_token_path        = var.secure ? aws_ssm_parameter.acl_token[0].name : ""
+  ecr_image_uri                 = var.ecr_image_uri
+  subnet_ids                    = var.private_subnets
+  security_group_ids            = [data.aws_security_group.vpc_default.id]
+  sync_frequency_in_minutes     = 1
+  partitions                    = local.enterprise ? ["default", var.consul_partition] : []
+  enterprise                    = local.enterprise
+  enable_auto_publish_ecr_image = var.enable_auto_publish_ecr_image
+  consul_extension_data_prefix  = "/${var.suffix}"
 }

--- a/test/acceptance/tests/setup/main.tf
+++ b/test/acceptance/tests/setup/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.14.0"
+      version = "4.67.0"
     }
   }
 }

--- a/test/acceptance/tests/setup/main.tf
+++ b/test/acceptance/tests/setup/main.tf
@@ -74,4 +74,5 @@ module "lambda-registration" {
   enterprise                    = local.enterprise
   enable_auto_publish_ecr_image = var.enable_auto_publish_ecr_image
   consul_extension_data_prefix  = "/${var.suffix}"
+  private_ecr_repo_name         = var.private_ecr_repo_name
 }

--- a/test/acceptance/tests/setup/variables.tf
+++ b/test/acceptance/tests/setup/variables.tf
@@ -75,3 +75,9 @@ variable "enable_auto_publish_ecr_image" {
   type        = bool
   default     = false
 }
+
+variable "private_ecr_repo_name" {
+  description = "The name of the repository to republish the ECR image if one exists. If no name is passed, it is assumed that no repository exists and one needs to be created."
+  type        = string
+  default     = ""
+}

--- a/test/acceptance/tests/setup/variables.tf
+++ b/test/acceptance/tests/setup/variables.tf
@@ -68,3 +68,9 @@ variable "consul_partition" {
 variable "consul_lambda_extension_arn" {
   type = string
 }
+
+variable "enable_auto_publish_ecr_image" {
+  description = "enables auto pushing public image to private ecr repo if set to true"
+  type        = bool
+  default     = false
+}

--- a/test/acceptance/tests/setup/variables.tf
+++ b/test/acceptance/tests/setup/variables.tf
@@ -71,11 +71,11 @@ variable "consul_lambda_extension_arn" {
 }
 
 variable "enable_auto_publish_ecr_image" {
-  type        = bool
-  default     = false
+  type    = bool
+  default = false
 }
 
 variable "private_ecr_repo_name" {
-  type        = string
-  default     = ""
+  type    = string
+  default = ""
 }

--- a/test/acceptance/tests/setup/variables.tf
+++ b/test/acceptance/tests/setup/variables.tf
@@ -48,6 +48,7 @@ variable "consul_image" {
 
 variable "ecr_image_uri" {
   type = string
+  default = ""
 }
 
 variable "consul_license" {

--- a/test/acceptance/tests/setup/variables.tf
+++ b/test/acceptance/tests/setup/variables.tf
@@ -71,13 +71,11 @@ variable "consul_lambda_extension_arn" {
 }
 
 variable "enable_auto_publish_ecr_image" {
-  description = "enables auto pushing public image to private ecr repo if set to true"
   type        = bool
   default     = false
 }
 
 variable "private_ecr_repo_name" {
-  description = "The name of the repository to republish the ECR image if one exists. If no name is passed, it is assumed that no repository exists and one needs to be created."
   type        = string
   default     = ""
 }

--- a/test/acceptance/tests/setup/variables.tf
+++ b/test/acceptance/tests/setup/variables.tf
@@ -47,7 +47,7 @@ variable "consul_image" {
 }
 
 variable "ecr_image_uri" {
-  type = string
+  type    = string
   default = ""
 }
 

--- a/test/acceptance/tests/validation/terraform/registrator-config-validate/main.tf
+++ b/test/acceptance/tests/validation/terraform/registrator-config-validate/main.tf
@@ -12,10 +12,10 @@ provider "aws" {
 }
 
 module "lambda-registration" {
-  source = "../../../../../../modules/lambda-registrator"
-  name = var.name
-  ecr_image_uri = var.ecr_image_uri
-  consul_http_addr = var.consul_http_addr
+  source                        = "../../../../../../modules/lambda-registrator"
+  name                          = var.name
+  ecr_image_uri                 = var.ecr_image_uri
+  consul_http_addr              = var.consul_http_addr
   enable_auto_publish_ecr_image = var.enable_auto_publish_ecr_image
 }
 
@@ -39,5 +39,5 @@ variable "enable_auto_publish_ecr_image" {
 }
 
 variable "consul_http_addr" {
-  type        = string
+  type = string
 }

--- a/test/acceptance/tests/validation/terraform/registrator-config-validate/main.tf
+++ b/test/acceptance/tests/validation/terraform/registrator-config-validate/main.tf
@@ -1,0 +1,43 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.67.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+module "lambda-registration" {
+  source = "../../../../../../modules/lambda-registrator"
+  name = var.name
+  ecr_image_uri = var.ecr_image_uri
+  consul_http_addr = var.consul_http_addr
+  enable_auto_publish_ecr_image = var.enable_auto_publish_ecr_image
+}
+
+variable "region" {
+  type    = string
+  default = "us-west-2"
+}
+
+variable "ecr_image_uri" {
+  type    = string
+  default = ""
+}
+variable "name" {
+  type    = string
+  default = ""
+}
+variable "enable_auto_publish_ecr_image" {
+  description = "enables auto pushing public image to private ecr repo if set to true"
+  type        = bool
+  default     = false
+}
+
+variable "consul_http_addr" {
+  type        = string
+}

--- a/test/acceptance/tests/validation/validation_test.go
+++ b/test/acceptance/tests/validation/validation_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestValidation_LambdaRegistrator(t *testing.T) {
+	t.Parallel()
 	terraformOpts := &terraform.Options{
 		TerraformDir: "./terraform/registrator-config-validate",
 		NoColor:      true,
@@ -57,7 +58,9 @@ func TestValidation_LambdaRegistrator(t *testing.T) {
 		},
 	}
 	for name, c := range cases {
+		c := c
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
 			_, err := terraform.PlanE(t, &terraform.Options{
 				TerraformDir: terraformOpts.TerraformDir,

--- a/test/acceptance/tests/validation/validation_test.go
+++ b/test/acceptance/tests/validation/validation_test.go
@@ -1,0 +1,77 @@
+package validation
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidation_LambdaRegistrator(t *testing.T) {
+	terraformOpts := &terraform.Options{
+		TerraformDir: "./terraform/registrator-config-validate",
+		NoColor:      true,
+	}
+	terraform.Init(t, terraformOpts)
+	cases := map[string]struct {
+		tfVars    map[string]interface{}
+		tfPlanErr string
+	}{
+		"ecr_image_uri and auto_publish not set": {
+			tfVars: map[string]interface{}{
+				"name":                          "test",
+				"consul_http_addr":              "https://consul.example.com:8501",
+				"ecr_image_uri":                 "",
+				"enable_auto_publish_ecr_image": false,
+			},
+			tfPlanErr: "ERROR: either ecr_image_uri or enable_auto_publish_ecr_image must be set",
+		},
+		"ecr_image_uri set and auto_publish not set": {
+			tfVars: map[string]interface{}{
+				"name":                          "test",
+				"consul_http_addr":              "https://consul.example.com:8501",
+				"ecr_image_uri":                 "123456789012.dkr.ecr.us-east-1.amazonaws.com/my-ecr-repo:latest",
+				"enable_auto_publish_ecr_image": false,
+			},
+			tfPlanErr: "",
+		},
+		"ecr_image_uri not set and auto_publish set": {
+			tfVars: map[string]interface{}{
+				"name":                          "test",
+				"consul_http_addr":              "https://consul.example.com:8501",
+				"ecr_image_uri":                 "",
+				"enable_auto_publish_ecr_image": true,
+			},
+			tfPlanErr: "",
+		},
+		"ecr_image_uri set and auto_publish set": {
+			tfVars: map[string]interface{}{
+				"name":                          "test",
+				"consul_http_addr":              "https://consul.example.com:8501",
+				"ecr_image_uri":                 "123456789012.dkr.ecr.us-east-1.amazonaws.com/my-ecr-repo:latest",
+				"enable_auto_publish_ecr_image": true,
+			},
+			tfPlanErr: "",
+		},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+
+			_, err := terraform.PlanE(t, &terraform.Options{
+				TerraformDir: terraformOpts.TerraformDir,
+				NoColor:      true,
+				Vars:         c.tfVars,
+			})
+			if c.tfPlanErr != "" {
+				require.Error(t, err)
+				// error messages are wrapped, so a space may turn into a newline.
+				regex := strings.ReplaceAll(regexp.QuoteMeta(c.tfPlanErr), " ", "\\s+")
+				require.Regexp(t, regex, err.Error())
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
…rivate ecr repo through terraform

## Changes proposed in this PR:
- Added support for pushing public lambda registrator image to a private ecr repo 

## How I've tested this PR:
tested by creating the lambda registrator through terraform
## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::