### PR TITLE
feature(iam): Allow an optional permissions boundary

### DIFF
--- a/modules/lambda-registrator/main.tf
+++ b/modules/lambda-registrator/main.tf
@@ -58,6 +58,8 @@ resource "aws_iam_role" "registration" {
   ]
 }
 EOF
+
+  permissions_boundary = var.aws_iam_permissions_boundary != "" ? var.aws.iam_permissions_boundary : null
 }
 
 resource "aws_iam_policy" "policy" {

--- a/modules/lambda-registrator/variables.tf
+++ b/modules/lambda-registrator/variables.tf
@@ -157,3 +157,9 @@ variable "arch" {
     error_message = "Invalid value for 'arch', options: 'arm64', 'x86_64'."
   }
 }
+
+variable "aws_iam_permissions_boundary" {
+  description = "Optional Permissions Boundary to add to the created IAM Role."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Changes proposed in this PR:

Support users and orgs that enforce permissions boundaries on their iam roles, by allowing one to be specified.

## How I've tested this PR:

I have deployed this module successfully to a test account

## How I expect reviewers to test this PR:

Deploy the module

## Checklist:
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::