### PR TITLE
Adds lambda:ListTags IAM action

### DIFF
--- a/modules/lambda-registrator/main.tf
+++ b/modules/lambda-registrator/main.tf
@@ -145,7 +145,14 @@ resource "aws_iam_policy" "policy" {
       ],
       "Resource": "*",
       "Effect": "Allow"
-    }
+    },
+    {
+      "Action": [
+        "lambda:ListTags"
+      ],
+      "Resource": "*",
+      "Effect": "Allow"
+    }    
   ]
 }
 EOF


### PR DESCRIPTION
## Changes proposed in this PR:
The registrator was not able to read tags without this policy.

## How I've tested this PR:
Added some logging to view what the events were, tags were empty until this policy was added.