### PR TITLE
chore: bump consul/api to v1.33.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BUG FIXES
 * Security:
-  * Upgrade to `github.com/hashicorp/consul` `v1.22.5`, `github.com/hashicorp/consul/api` `v1.33.3`, and `github.com/hashicorp/consul/sdk` `v0.17.2` to pick up the Consul fixes for `CVE-2025-11375` and `CVE-2025-11374`. [[GH-122]](https://github.com/hashicorp/terraform-aws-consul-lambda/pull/122)
+  * Upgrade to `github.com/hashicorp/consul` `v1.22.5`, `github.com/hashicorp/consul/api` `v1.33.4`, and `github.com/hashicorp/consul/sdk` `v0.17.2` to pick up the Consul fixes for `CVE-2025-11375` and `CVE-2025-11374`. [[GH-122]](https://github.com/hashicorp/terraform-aws-consul-lambda/pull/122)
   * Upgrade `google.golang.org/grpc` to `v1.79.3` in the acceptance test module to address the gRPC-Go authorization bypass caused by malformed HTTP/2 `:path` values. [[GH-122]](https://github.com/hashicorp/terraform-aws-consul-lambda/pull/122)
 * Compatibility:
   * Align the AWS SDK v2 Lambda and SSM service clients with the updated dependency graph and update the registrator SSM client for the newer SDK request types. [[GH-122]](https://github.com/hashicorp/terraform-aws-consul-lambda/pull/122)

--- a/consul-lambda/go.mod
+++ b/consul-lambda/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.2
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/consul v1.22.5
-	github.com/hashicorp/consul/api v1.33.3
+	github.com/hashicorp/consul/api v1.33.4
 	github.com/hashicorp/consul/sdk v0.17.2
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-multierror v1.1.1

--- a/consul-lambda/go.sum
+++ b/consul-lambda/go.sum
@@ -119,8 +119,8 @@ github.com/hashicorp/consul v1.22.5 h1:3tA8hCxJNvDpbsWKrVHkWpzkaWHssjKLdotKborZc
 github.com/hashicorp/consul v1.22.5/go.mod h1:ijf2WM2RmxCFr8HXjHRhMkbd71Z4uVRPX4c5kQx/QZw=
 github.com/hashicorp/consul-net-rpc v0.0.0-20221205195236-156cfab66a69 h1:wzWurXrxfSyG1PHskIZlfuXlTSCj1Tsyatp9DtaasuY=
 github.com/hashicorp/consul-net-rpc v0.0.0-20221205195236-156cfab66a69/go.mod h1:svUZZDvotY8zTODknUePc6mZ9pX8nN0ViGwWcUSOBEA=
-github.com/hashicorp/consul/api v1.33.3 h1:6ttDO8Os/lqwaus7nJxJaeiUw2o7GWKoQ1jexAFPdEQ=
-github.com/hashicorp/consul/api v1.33.3/go.mod h1:1HoAkxkKpC8A9lsUYs7QCMfSSKiz6+vlfrI1J3PUEeI=
+github.com/hashicorp/consul/api v1.33.4 h1:AJkZp6qzgAYcMIU0+CjJ0Rb7+byfh0dazFK/gzlOcJk=
+github.com/hashicorp/consul/api v1.33.4/go.mod h1:BkH3WEUzsnWvJJaHoDqKqoe2Q2EIixx7Gjj6MTwYnOA=
 github.com/hashicorp/consul/envoyextensions v0.9.2 h1:78/i3IM72MEV0UBFrMdzQ9agQtNWU8Bk6gigjnH6xY8=
 github.com/hashicorp/consul/envoyextensions v0.9.2/go.mod h1:aZrZ4yZ6RCLuaRJYDvG77vtT9J7xGTPqodqkd8klNz8=
 github.com/hashicorp/consul/proto-public v0.7.1 h1:jWckjXYpgq92qg9TpR7Y9/cAjLvwjHAb8iP8XdZYk8c=


### PR DESCRIPTION
## Summary
- follow up on GH-122 with the same released dependency set
- bump `github.com/hashicorp/consul/api` from `v1.33.3` to `v1.33.4`
- update the unreleased changelog entry to match the new API patch version

## Validation
- ran `go build ./...` in `consul-lambda`
